### PR TITLE
Split metadata out of Item/SlotTile

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,13 +1,14 @@
 use std::collections::BTreeMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
-#[cfg(not(target_arch = "wasm32"))]
+use egui::{Align2, Color32, NumExt, Pos2, Rect, ScrollArea, Slider, Stroke, TextStyle, Vec2};
+use serde::{Deserialize, Serialize};
+
 use crate::data::{
     DataSource, EntryID, EntryInfo, Field, SlotMetaTile, SlotTile, TileID, UtilPoint,
 };
 use crate::timestamp::Interval;
-use egui::{Align2, Color32, NumExt, Pos2, Rect, ScrollArea, Slider, Stroke, TextStyle, Vec2};
-use serde::{Deserialize, Serialize};
 
 /// Overview:
 ///   ProfApp -> Context, Window *

--- a/src/app.rs
+++ b/src/app.rs
@@ -368,6 +368,7 @@ impl Slot {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_tile(
         &mut self,
         tile_index: usize,

--- a/src/data.rs
+++ b/src/data.rs
@@ -53,11 +53,15 @@ pub enum Field {
 pub struct Item {
     pub interval: Interval,
     pub color: Color32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ItemMeta {
     pub title: String,
     pub fields: Vec<(String, Field)>,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct TileID(pub Interval);
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -72,12 +76,19 @@ pub struct SlotTile {
     pub items: Vec<Vec<Item>>, // row -> [item]
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SlotMetaTile {
+    pub tile_id: TileID,
+    pub items: Vec<Vec<ItemMeta>>, // row -> [item]
+}
+
 pub trait DataSource {
     fn interval(&mut self) -> Interval;
     fn fetch_info(&mut self) -> &EntryInfo;
     fn request_tiles(&mut self, entry_id: &EntryID, request_interval: Interval) -> Vec<TileID>;
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile;
     fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotTile;
+    fn fetch_slot_meta_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotMetaTile;
 }
 
 impl EntryID {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use rand::Rng;
 use std::collections::BTreeMap;
 
 use legion_prof_viewer::data::{
-    DataSource, EntryID, EntryInfo, Field, Item, SlotTile, SummaryTile, TileID, UtilPoint,
+    DataSource, EntryID, EntryInfo, Field, Item, ItemMeta, SlotMetaTile, SlotTile, SummaryTile,
+    TileID, UtilPoint,
 };
 use legion_prof_viewer::timestamp::{Interval, Timestamp};
 
@@ -22,7 +23,7 @@ struct RandomDataSource {
     info: Option<EntryInfo>,
     interval: Option<Interval>,
     summary_cache: BTreeMap<EntryID, Vec<UtilPoint>>,
-    slot_cache: BTreeMap<EntryID, Vec<Vec<Item>>>,
+    slot_cache: BTreeMap<EntryID, (Vec<Vec<Item>>, Vec<Vec<ItemMeta>>)>,
     rng: rand::rngs::ThreadRng,
 }
 
@@ -70,7 +71,7 @@ impl RandomDataSource {
         self.summary_cache.get(entry_id).unwrap()
     }
 
-    fn generate_slot(&mut self, entry_id: &EntryID) -> &Vec<Vec<Item>> {
+    fn generate_slot(&mut self, entry_id: &EntryID) -> &(Vec<Vec<Item>>, Vec<Vec<ItemMeta>>) {
         if !self.slot_cache.contains_key(entry_id) {
             let entry = self.fetch_info().get(entry_id);
 
@@ -81,8 +82,10 @@ impl RandomDataSource {
             };
 
             let mut items = Vec::new();
+            let mut item_metas = Vec::new();
             for row in 0..*max_rows {
                 let mut row_items = Vec::new();
+                let mut row_item_metas = Vec::new();
                 const N: u64 = 1000;
                 for i in 0..N {
                     let start = self.interval().lerp((i as f32 + 0.05) / (N as f32));
@@ -102,6 +105,8 @@ impl RandomDataSource {
                     row_items.push(Item {
                         interval: Interval::new(start, stop),
                         color,
+                    });
+                    row_item_metas.push(ItemMeta {
                         title: "Test Item".to_owned(),
                         fields: vec![(
                             "Interval".to_owned(),
@@ -110,9 +115,11 @@ impl RandomDataSource {
                     });
                 }
                 items.push(row_items);
+                item_metas.push(row_item_metas);
             }
 
-            self.slot_cache.insert(entry_id.clone(), items);
+            self.slot_cache
+                .insert(entry_id.clone(), (items, item_metas));
         }
         self.slot_cache.get(entry_id).unwrap()
     }
@@ -248,7 +255,7 @@ impl DataSource for RandomDataSource {
     }
 
     fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotTile {
-        let items = self.generate_slot(entry_id);
+        let items = &self.generate_slot(entry_id).0;
 
         let mut slot_items = Vec::new();
         for row in items {
@@ -266,6 +273,28 @@ impl DataSource for RandomDataSource {
         }
 
         SlotTile {
+            tile_id,
+            items: slot_items,
+        }
+    }
+
+    fn fetch_slot_meta_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotMetaTile {
+        let (items, item_metas) = &self.generate_slot(entry_id);
+
+        let mut slot_items = Vec::new();
+        for (row, row_meta) in items.iter().zip(item_metas.iter()) {
+            let mut slot_row = Vec::new();
+            for (item, item_meta) in row.iter().zip(row_meta.iter()) {
+                // When the item straddles a tile boundary, it has to be
+                // sliced to fit
+                if tile_id.0.overlaps(item.interval) {
+                    slot_row.push(item_meta.clone());
+                }
+            }
+            slot_items.push(slot_row);
+        }
+
+        SlotMetaTile {
             tile_id,
             items: slot_items,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ impl RandomDataSource {
         self.summary_cache.get(entry_id).unwrap()
     }
 
-    fn generate_slot(&mut self, entry_id: &EntryID) -> &(Vec<Vec<Item>>, Vec<Vec<ItemMeta>>) {
+    fn generate_slot(&mut self, entry_id: &EntryID) -> &SlotCacheTile {
         if !self.slot_cache.contains_key(entry_id) {
             let entry = self.fetch_info().get(entry_id);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,14 @@ fn main() {
     );
 }
 
+type SlotCacheTile = (Vec<Vec<Item>>, Vec<Vec<ItemMeta>>);
+
 #[derive(Default)]
 struct RandomDataSource {
     info: Option<EntryInfo>,
     interval: Option<Interval>,
     summary_cache: BTreeMap<EntryID, Vec<UtilPoint>>,
-    slot_cache: BTreeMap<EntryID, (Vec<Vec<Item>>, Vec<Vec<ItemMeta>>)>,
+    slot_cache: BTreeMap<EntryID, SlotCacheTile>,
     rng: rand::rngs::ThreadRng,
 }
 


### PR DESCRIPTION
This PR splits the metadata (all strings/fields) out of `Item` and `SlotTile`. There are now two new types:

  * `ItemMeta`: the metadata for an `Item`
  * `SlotMetaTile`: the collected metadata for all `Item`s in a `SlotTile`

Because we don't need this until we hover or perform an action like a search, we can lazy-load the metadata and make the app more responsive. As the metadata gets richer, these benefits are expected to grow.

This isn't 100% ready yet because I ran into some trouble with the borrow checker in `app.rs` and the current solution is a bit of a hack.