### PR TITLE
Support for spans

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -50,15 +50,28 @@ pub enum Field {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Span {
+    pub interval: Interval,
+    pub color: Color32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SpanMeta {
+    pub fields: Vec<(String, Field)>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Item {
     pub interval: Interval,
     pub color: Color32,
+    pub spans: Vec<Span>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ItemMeta {
     pub title: String,
     pub fields: Vec<(String, Field)>,
+    pub spans: Vec<SpanMeta>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ impl RandomDataSource {
                     row_items.push(Item {
                         interval: Interval::new(start, stop),
                         color,
+                        spans: Vec::new(),
                     });
                     row_item_metas.push(ItemMeta {
                         title: "Test Item".to_owned(),
@@ -114,6 +115,7 @@ impl RandomDataSource {
                             "Interval".to_owned(),
                             Field::Interval(Interval::new(start, stop)),
                         )],
+                        spans: Vec::new(),
                     });
                 }
                 items.push(row_items);


### PR DESCRIPTION
This adds two new data types: `Span` and `SpanMeta`. Each `Item` may contain 0 or more `Span`s and each `ItemMeta` has 0 or more `SpanMeta`. The purpose of a span is to track intervals within an item where certain properties apply (e.g., a task may be running, blocked, ready, etc.).

The reason to do this with a nested data type rather than splitting items is because an item as a whole is a unit that we may want to reference. In practice, items that get split have a high level of duplication (since most of the fields in an item do not vary with the wait state), making this hopefully an overall savings vs forcing the backend to split items.