### PR TITLE
Make DataSource immutable to enable concurrent access

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -117,11 +117,37 @@ pub struct SlotMetaTile {
 }
 
 pub trait DataSource {
+    fn fetch_info(&self) -> DataSourceInfo;
+    fn fetch_tile_set(&self) -> TileSet;
+    fn fetch_summary_tile(&self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile;
+    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID) -> SlotTile;
+    fn fetch_slot_meta_tile(&self, entry_id: &EntryID, tile_id: TileID) -> SlotMetaTile;
+}
+
+pub trait DataSourceMut {
     fn fetch_info(&mut self) -> DataSourceInfo;
     fn fetch_tile_set(&mut self) -> TileSet;
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile;
     fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotTile;
     fn fetch_slot_meta_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotMetaTile;
+}
+
+impl<T: DataSource> DataSourceMut for T {
+    fn fetch_info(&mut self) -> DataSourceInfo {
+        DataSource::fetch_info(self)
+    }
+    fn fetch_tile_set(&mut self) -> TileSet {
+        DataSource::fetch_tile_set(self)
+    }
+    fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile {
+        DataSource::fetch_summary_tile(self, entry_id, tile_id)
+    }
+    fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotTile {
+        DataSource::fetch_slot_tile(self, entry_id, tile_id)
+    }
+    fn fetch_slot_meta_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotMetaTile {
+        DataSource::fetch_slot_meta_tile(self, entry_id, tile_id)
+    }
 }
 
 impl EntryID {

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    DataSource, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID, TileSet,
+    DataSourceInfo, DataSourceMut, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID, TileSet,
 };
 
 pub trait DeferredDataSource {
@@ -16,7 +16,7 @@ pub trait DeferredDataSource {
 }
 
 pub struct DeferredDataSourceWrapper {
-    data_source: Box<dyn DataSource>,
+    data_source: Box<dyn DataSourceMut>,
     infos: Vec<DataSourceInfo>,
     tile_sets: Vec<TileSet>,
     summary_tiles: Vec<SummaryTile>,
@@ -25,7 +25,7 @@ pub struct DeferredDataSourceWrapper {
 }
 
 impl DeferredDataSourceWrapper {
-    pub fn new(data_source: Box<dyn DataSource>) -> Self {
+    pub fn new(data_source: Box<dyn DataSourceMut>) -> Self {
         Self {
             data_source,
             infos: Vec::new(),

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use actix_cors::Cors;
 use actix_web::{
@@ -11,7 +11,7 @@ use crate::data::DataSource;
 use crate::http::schema::TileRequest;
 
 pub struct AppState {
-    pub data_source: Mutex<Box<dyn DataSource + Send + Sync + 'static>>,
+    pub data_source: Box<dyn DataSource + Send + Sync + 'static>,
 }
 
 pub struct DataSourceHTTPServer {
@@ -29,21 +29,17 @@ impl DataSourceHTTPServer {
         Self {
             host,
             port,
-            state: AppState {
-                data_source: Mutex::new(data_source),
-            },
+            state: AppState { data_source },
         }
     }
 
     async fn fetch_info(state: web::Data<AppState>) -> Result<impl Responder> {
-        let mut data_source = state.data_source.lock().unwrap();
-        let result = data_source.fetch_info();
+        let result = state.data_source.fetch_info();
         Ok(web::Json(result))
     }
 
     async fn fetch_tile_set(state: web::Data<AppState>) -> Result<impl Responder> {
-        let mut data_source = state.data_source.lock().unwrap();
-        let result = data_source.fetch_tile_set();
+        let result = state.data_source.fetch_tile_set();
         Ok(web::Json(result))
     }
 
@@ -51,8 +47,9 @@ impl DataSourceHTTPServer {
         req: web::Json<TileRequest>,
         state: web::Data<AppState>,
     ) -> Result<impl Responder> {
-        let mut data_source = state.data_source.lock().unwrap();
-        let result = data_source.fetch_summary_tile(&req.entry_id, req.tile_id);
+        let result = state
+            .data_source
+            .fetch_summary_tile(&req.entry_id, req.tile_id);
         Ok(web::Json(result))
     }
 
@@ -60,8 +57,9 @@ impl DataSourceHTTPServer {
         req: web::Json<TileRequest>,
         state: web::Data<AppState>,
     ) -> Result<impl Responder> {
-        let mut data_source = state.data_source.lock().unwrap();
-        let result = data_source.fetch_slot_tile(&req.entry_id, req.tile_id);
+        let result = state
+            .data_source
+            .fetch_slot_tile(&req.entry_id, req.tile_id);
         Ok(web::Json(result))
     }
 
@@ -69,8 +67,9 @@ impl DataSourceHTTPServer {
         req: web::Json<TileRequest>,
         state: web::Data<AppState>,
     ) -> Result<impl Responder> {
-        let mut data_source = state.data_source.lock().unwrap();
-        let result = data_source.fetch_slot_meta_tile(&req.entry_id, req.tile_id);
+        let result = state
+            .data_source
+            .fetch_slot_meta_tile(&req.entry_id, req.tile_id);
         Ok(web::Json(result))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use rand::Rng;
 use std::collections::BTreeMap;
 
 use legion_prof_viewer::data::{
-    DataSource, DataSourceInfo, EntryID, EntryInfo, Field, Item, ItemMeta, ItemUID, SlotMetaTile,
-    SlotMetaTileData, SlotTile, SlotTileData, SummaryTile, SummaryTileData, TileID, TileSet,
-    UtilPoint,
+    DataSourceInfo, DataSourceMut, EntryID, EntryInfo, Field, Item, ItemMeta, ItemUID,
+    SlotMetaTile, SlotMetaTileData, SlotTile, SlotTileData, SummaryTile, SummaryTileData, TileID,
+    TileSet, UtilPoint,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -263,7 +263,7 @@ impl RandomDataSource {
     }
 }
 
-impl DataSource for RandomDataSource {
+impl DataSourceMut for RandomDataSource {
     fn fetch_info(&mut self) -> DataSourceInfo {
         DataSourceInfo {
             entry_info: self.entry_info().clone(),


### PR DESCRIPTION
This permits the `DataSource` HTTP server to serve requests in parallel.