### PR TITLE
Add search interface (refactored)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,3 +23,5 @@
 - [ ] Search (with load all data option to get better search results)
 - [ ] Task detail view
 - [ ] Keyboard bindings (e.g., arrow keys to select panels, space bar to toggle expand/collapse)
+- [ ] Open window to show key bindings
+- [ ] Editable key bindings?

--- a/src/app.rs
+++ b/src/app.rs
@@ -1041,9 +1041,8 @@ impl SearchState {
 
         let mut result = true;
         // Always called second, so we know the entry exists.
-        self.result_cache
-            .get_mut(entry.entry_id())
-            .unwrap()
+        let cache = self.result_cache.get_mut(entry.entry_id()).unwrap();
+        cache
             .entry(tile_id)
             .and_modify(|_| {
                 result = false;
@@ -1060,11 +1059,9 @@ impl SearchState {
         // We want each item to appear once, so check the result set first
         // before inserting.
         if self.result_set.insert(item.item_uid) {
-            self.result_cache
-                .get_mut(entry.entry_id())
-                .unwrap()
-                .get_mut(&tile_id)
-                .unwrap()
+            let cache = self.result_cache.get_mut(entry.entry_id()).unwrap();
+            let cache = cache.get_mut(&tile_id).unwrap();
+            cache
                 .entry(item.item_uid)
                 .or_insert_with(|| SearchCacheItem {
                     irow,
@@ -1378,12 +1375,8 @@ impl Window {
                                     let level2_slot =
                                         &mut level1_slot.slots[*level2_index as usize];
                                     ui.collapsing(&level2_slot.long_name, |ui| {
-                                        let cache = self
-                                            .config
-                                            .search_state
-                                            .result_cache
-                                            .get(&level2_slot.entry_id)
-                                            .unwrap();
+                                        let cache = &self.config.search_state.result_cache;
+                                        let cache = cache.get(&level2_slot.entry_id).unwrap();
                                         for tile_cache in cache.values() {
                                             for item in tile_cache.values() {
                                                 let button =

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,8 +10,8 @@ use egui::{
 use serde::{Deserialize, Serialize};
 
 use crate::data::{
-    DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, SlotMetaTileData, SlotTileData,
-    SummaryTileData, TileID, UtilPoint,
+    DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, ItemMeta, ItemUID, SlotMetaTileData,
+    SlotTileData, SummaryTileData, TileID, UtilPoint,
 };
 use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource};
 use crate::timestamp::{Interval, Timestamp, TimestampParseError};
@@ -75,6 +75,11 @@ struct Panel<S: Entry> {
     slots: Vec<S>,
 }
 
+#[derive(Default)]
+struct SearchState {
+    cache: BTreeMap<EntryID, BTreeMap<TileID, BTreeMap<ItemUID, ItemMeta>>>,
+}
+
 struct Config {
     // Node selection controls
     min_node: u64,
@@ -84,6 +89,8 @@ struct Config {
     interval: Interval,
 
     data_source: CountingDeferredDataSource<Box<dyn DeferredDataSource>>,
+
+    search_state: SearchState,
 }
 
 struct Window {
@@ -855,6 +862,7 @@ impl Config {
             max_node,
             interval,
             data_source: CountingDeferredDataSource::new(data_source),
+            search_state: SearchState::default(),
         }
     }
 
@@ -1029,6 +1037,14 @@ impl Window {
         if ui.button("Reset Zoom Level").clicked() {
             ProfApp::zoom(cx, cx.total_interval);
         }
+    }
+
+    fn search(&mut self, query: &str, cx: &mut Context) {
+        // 1. Expand all meta tiles. Including collapsed entries.
+        // 2. Search whatever data we have. Results are cached by entry/tile.
+        // 3. Done? Modify draw code to highlight cached items.
+        // 4. Cache invalidation. Maybe on zoom?
+        // 5. Code to render search results (hint: use cache).
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1013,7 +1013,7 @@ impl SearchState {
         item.title.contains(&self.query)
     }
 
-    const MAX_SEARCH_RESULTS: usize = 10000;
+    const MAX_SEARCH_RESULTS: usize = 100_000;
 
     fn start_entry<E: Entry>(&mut self, entry: &E) -> bool {
         // Early exit if we found enough items.

--- a/src/app.rs
+++ b/src/app.rs
@@ -80,11 +80,8 @@ struct SearchCacheItem {
     // For horizontal scroll, we need the item's interval
     interval: Interval,
 
-    // For vertical scroll, we need the item's location
+    // For vertical scroll, we need the item's entry
     entry_id: EntryID,
-    tile_id: TileID,
-    row: usize,
-    col: usize,
 
     // Cache fields for display
     title: String,
@@ -686,10 +683,10 @@ impl Entry for Slot {
                     continue;
                 }
 
-                for (row, row_items) in tile.items.iter().enumerate() {
-                    for (col, item) in row_items.iter().enumerate() {
+                for row_items in &tile.items {
+                    for item in row_items {
                         if config.search_state.is_match(item) {
-                            config.search_state.insert(self, *tile_id, row, col, item);
+                            config.search_state.insert(self, *tile_id, item);
                         }
                     }
                 }
@@ -1044,14 +1041,7 @@ impl SearchState {
         result
     }
 
-    fn insert<E: Entry>(
-        &mut self,
-        entry: &E,
-        tile_id: TileID,
-        row: usize,
-        col: usize,
-        item: &ItemMeta,
-    ) {
+    fn insert<E: Entry>(&mut self, entry: &E, tile_id: TileID, item: &ItemMeta) {
         if self.result_set.len() >= Self::MAX_SEARCH_RESULTS {
             return;
         }
@@ -1068,9 +1058,6 @@ impl SearchState {
                 .or_insert_with(|| SearchCacheItem {
                     interval: item.original_interval,
                     entry_id: entry.entry_id().clone(),
-                    tile_id: tile_id,
-                    row,
-                    col,
                     title: item.title.clone(),
                 });
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -663,11 +663,11 @@ impl Entry for Slot {
         }
 
         for (tile_id, tile) in &self.tile_metas {
-            if !config.search_state.start_tile(self, *tile_id) {
-                continue;
-            }
-
             if let Some(tile) = tile {
+                if !config.search_state.start_tile(self, *tile_id) {
+                    continue;
+                }
+
                 for (row, row_items) in tile.items.iter().enumerate() {
                     for (col, item) in row_items.iter().enumerate() {
                         if config.search_state.is_match(item) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -999,7 +999,7 @@ impl SearchState {
     }
 
     fn is_match(&self, item: &ItemMeta) -> bool {
-        item.title.find(&self.query).is_some()
+        item.title.contains(&self.query)
     }
 
     const MAX_SEARCH_RESULTS: usize = 1000;

--- a/src/app.rs
+++ b/src/app.rs
@@ -234,7 +234,7 @@ trait Entry {
 
     fn inflate_meta(&mut self, config: &mut Config, cx: &mut Context);
 
-    fn search(&mut self, config: &mut Config, cx: &mut Context);
+    fn search(&mut self, config: &mut Config);
 
     fn label(&mut self, ui: &mut egui::Ui, rect: Rect) {
         let response = ui.allocate_rect(
@@ -341,9 +341,13 @@ impl Entry for Summary {
         unreachable!()
     }
 
-    fn inflate_meta(&mut self, _config: &mut Config, _cx: &mut Context) {}
+    fn inflate_meta(&mut self, _config: &mut Config, _cx: &mut Context) {
+        unreachable!()
+    }
 
-    fn search(&mut self, _config: &mut Config, _cx: &mut Context) {}
+    fn search(&mut self, _config: &mut Config) {
+        unreachable!()
+    }
 
     fn content(
         &mut self,
@@ -671,7 +675,7 @@ impl Entry for Slot {
         }
     }
 
-    fn search(&mut self, config: &mut Config, cx: &mut Context) {
+    fn search(&mut self, config: &mut Config) {
         if !config.search_state.start_entry(self) {
             return;
         }
@@ -880,7 +884,7 @@ impl<S: Entry> Entry for Panel<S> {
         }
     }
 
-    fn search(&mut self, config: &mut Config, cx: &mut Context) {
+    fn search(&mut self, config: &mut Config) {
         let force = config.search_state.include_collapsed_entries;
         if self.expanded || force {
             for slot in &mut self.slots {
@@ -889,7 +893,7 @@ impl<S: Entry> Entry for Panel<S> {
                     continue;
                 }
 
-                slot.search(config, cx);
+                slot.search(config);
             }
         }
     }
@@ -1271,7 +1275,7 @@ impl Window {
         self.panel.inflate_meta(&mut self.config, cx);
 
         // Search whatever data we have. Results are cached by entry/tile.
-        self.panel.search(&mut self.config, cx);
+        self.panel.search(&mut self.config);
 
         // Cache is now full and we can highlight/render the entries.
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -658,8 +658,8 @@ impl Entry for Slot {
     fn search(&mut self, config: &mut Config, cx: &mut Context) {
         config.search_state.start_entry(self);
         for (tile_id, tile) in &self.tile_metas {
-            if config.search_state.start_tile(self, *tile_id) {
-                return;
+            if !config.search_state.start_tile(self, *tile_id) {
+                continue;
             }
 
             if let Some(tile) = tile {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1355,34 +1355,20 @@ impl Window {
         }
 
         self.config.search_state.build_entry_tree();
-        let num_rows: u64 = self.config.search_state.entry_tree.values().map(|(x, _)| x).sum();
 
         ScrollArea::vertical()
             // Hack: estimate size of bottom UI.
             .max_height(ui.available_height() - 70.0)
             .auto_shrink([false; 2])
-            .show_rows(ui, cx.row_height, num_rows as usize, |ui, row_range| {
-                let mut row_index = 0;
+            .show(ui, |ui| {
                 let root_tree = &self.config.search_state.entry_tree;
-                for (level0_index, (level0_count, level0_subtree)) in root_tree {
-                    if row_index + level0_count < row_range.start as u64 {
-                        row_index += level0_count;
-                        continue;
-                    }
+                for (level0_index, (_, level0_subtree)) in root_tree {
                     let level0_slot = &mut self.panel.slots[*level0_index as usize];
                     ui.collapsing(&level0_slot.long_name, |ui| {
-                        for (level1_index, (level1_count, level1_subtree)) in level0_subtree {
-                            if row_index + level1_count < row_range.start as u64 {
-                                row_index += level1_count;
-                                continue;
-                            }
+                        for (level1_index, (_, level1_subtree)) in level0_subtree {
                             let level1_slot = &mut level0_slot.slots[*level1_index as usize];
                             ui.collapsing(&level1_slot.long_name, |ui| {
-                                for (level2_index, level2_count) in level1_subtree {
-                                    if row_index + level2_count < row_range.start as u64 {
-                                        row_index += level2_count;
-                                        continue;
-                                    }
+                                for level2_index in level1_subtree.keys() {
                                     let level2_slot = &mut level1_slot.slots[*level2_index as usize];
                                     ui.collapsing(&level2_slot.long_name, |ui| {
                                         let cache = self.config.search_state.result_cache.get(&level2_slot.entry_id).unwrap();

--- a/src/app.rs
+++ b/src/app.rs
@@ -576,7 +576,7 @@ impl Slot {
                 }
 
                 let mut color = item.color;
-                if !config.search_state.result_set.is_empty() {
+                if !config.search_state.query.is_empty() {
                     if config.search_state.result_set.contains(&item.item_uid) {
                         color = Color32::RED;
                     } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -197,6 +197,7 @@ struct Context {
 
     debug: bool,
 
+    #[serde(skip)]
     zoom_state: ZoomState,
     #[serde(skip)]
     interval_state: IntervalSelectState,
@@ -1194,8 +1195,6 @@ impl Window {
                     }
                     cx.view_interval.start = start;
                     ProfApp::zoom(cx, cx.view_interval);
-                    cx.interval_state.start_error = None;
-                    cx.interval_state.stop_error = None;
                 }
                 Err(e) => {
                     cx.interval_state.start_error = Some(e.into());
@@ -1214,8 +1213,6 @@ impl Window {
                     }
                     cx.view_interval.stop = stop;
                     ProfApp::zoom(cx, cx.view_interval);
-                    cx.interval_state.start_error = None;
-                    cx.interval_state.stop_error = None;
                 }
                 Err(e) => {
                     cx.interval_state.stop_error = Some(e.into());
@@ -1390,6 +1387,8 @@ impl ProfApp {
         cx.zoom_state.index = cx.zoom_state.levels.len() - 1;
         cx.interval_state.start_buffer = cx.view_interval.start.to_string();
         cx.interval_state.stop_buffer = cx.view_interval.stop.to_string();
+        cx.interval_state.start_error = None;
+        cx.interval_state.stop_error = None;
     }
 
     fn undo_zoom(cx: &mut Context) {
@@ -1400,6 +1399,8 @@ impl ProfApp {
         cx.view_interval = cx.zoom_state.levels[cx.zoom_state.index];
         cx.interval_state.start_buffer = cx.view_interval.start.to_string();
         cx.interval_state.stop_buffer = cx.view_interval.stop.to_string();
+        cx.interval_state.start_error = None;
+        cx.interval_state.stop_error = None;
     }
 
     fn redo_zoom(cx: &mut Context) {
@@ -1410,6 +1411,8 @@ impl ProfApp {
         cx.view_interval = cx.zoom_state.levels[cx.zoom_state.index];
         cx.interval_state.start_buffer = cx.view_interval.start.to_string();
         cx.interval_state.stop_buffer = cx.view_interval.stop.to_string();
+        cx.interval_state.start_error = None;
+        cx.interval_state.stop_error = None;
     }
 
     fn keyboard(ctx: &egui::Context, cx: &mut Context) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -568,7 +568,17 @@ impl Slot {
                     hover_pos = None;
                     interact_item = Some((row, item_idx, item_rect, tile_id));
                 }
-                ui.painter().rect(item_rect, 0.0, item.color, Stroke::NONE);
+
+                let mut color = item.color;
+                if !config.search_state.result_set.is_empty() {
+                    if config.search_state.result_set.contains(&item.item_uid) {
+                        color = Color32::RED;
+                    } else {
+                        color = color.gamma_multiply(0.2);
+                    }
+                }
+
+                ui.painter().rect(item_rect, 0.0, color, Stroke::NONE);
             }
         }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -68,6 +68,10 @@ pub struct Item {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ItemMeta {
     pub item_uid: ItemUID,
+    // As opposed to the interval in Item, which may get expanded for
+    // visibility, or sliced up into multiple tiles, this interval covers the
+    // entire duration of the original item, unexpanded and unsliced.
+    pub original_interval: Interval,
     pub title: String,
     pub fields: Vec<(String, Field)>,
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -204,6 +204,18 @@ impl EntryID {
                 .map_or(EntryIndex::Summary, EntryIndex::Slot),
         )
     }
+
+    pub fn has_prefix(&self, prefix: &EntryID) -> bool {
+        if prefix.0.len() > self.0.len() {
+            return false;
+        }
+        for (a, b) in self.0.iter().zip(prefix.0.iter()) {
+            if a != b {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 impl EntryInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,7 @@ impl RandomDataSource {
                     });
                     row_item_metas.push(ItemMeta {
                         item_uid,
+                        original_interval: Interval::new(start, stop),
                         title: "Test Item".to_owned(),
                         fields: vec![
                             (

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -156,6 +156,13 @@ impl Interval {
     pub fn lerp(self, value: f32) -> Timestamp {
         Timestamp((value * (self.duration_ns() as f32)).round() as i64 + self.start.0)
     }
+    // Grow (shrink) interval by duration_ns on either side.
+    pub fn grow(self, duration_ns: i64) -> Self {
+        Self {
+            start: Timestamp(self.start.0 - duration_ns),
+            stop: Timestamp(self.stop.0 + duration_ns),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a refactored/modified version of #17. Notable changes:

 * Search is disentangled from draw code. The search routine now:
    1. Fetches all meta tiles. We do this up front because we know we'll need all of them.
    2. Searches all tiles to generate a cache. Again this happens up front.
    3. Now the cache is populated so we can display and highlight separately.
 * Search is now done on a tile-by-tile basis. This makes it work with the asynchronous data fetch as results are streaming in. It also helps minimize the size of the cache by reusing common data (e.g., `EntryID`).
 * One huge advantage of not messing with the draw code is that now we don't need to deoptimize the culling algorithm, even when search is enabled. In the past, we needed this to implement vertical scroll to item (because the item wasn't necessarily on the screen when the user clicked the search result). We now compute the item's location directly and scroll to that point, making it unnecessary to mess with culling or the draw code.
 * Fixed a pretty bad scroll bug in the search result area. (In multi-node profiles, after expanding the node list, you'd never see the second node.) This costs us a performance optimization, which is unfortunate, but my conclusion is that there is fundamentally no way to implement this correctly in egui (i.e., a scrollable area with rows of nonuniform sizes). If we want the optimized fix, it will require something like what I did for the main viewer (i.e., nested panels of nonuniform size), which I'm not willing to implement right now.
 * Fixed the double zoom bug. Not sure how it happened in the original, but the workaround is no longer necessary.
 * Fixed a weird alignment bug with the &times; button. Turns out right-to-left layout is screwy, but you avoid the problem by precomputing the button size. Not pretty though.
 * The search UI is now properly per-window. We're kind of tight on space though, so I'm thinking about whether we need to refactor the UI to save vertical space.
 * The code still uses a deeply nested loop, but it's limited to the search result display code. I thought about trying to fix this (since it's not pretty), but decided it wasn't worth the effort because it requires building a parallel type hierarchy for the entry tree (and also would be tricky to figure out re: mutable lifetimes). Removed the nested break through.
 * No fuzzy search, yet. I'm considering it, but I want to testdrive this first to see how people use it before committing to the extra complexity. Other options include regex search or searching other fields besides title.