### PR TITLE
Use the tile set to render static profiles

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -22,6 +22,7 @@ pub enum EntryIndex {
 pub struct DataSourceInfo {
     pub entry_info: EntryInfo,
     pub interval: Interval,
+    pub tile_set: TileSet,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -124,7 +125,6 @@ pub struct SlotMetaTile {
 
 pub trait DataSource {
     fn fetch_info(&self) -> DataSourceInfo;
-    fn fetch_tile_set(&self) -> TileSet;
     fn fetch_summary_tile(&self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile;
     fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID) -> SlotTile;
     fn fetch_slot_meta_tile(&self, entry_id: &EntryID, tile_id: TileID) -> SlotMetaTile;
@@ -132,7 +132,6 @@ pub trait DataSource {
 
 pub trait DataSourceMut {
     fn fetch_info(&mut self) -> DataSourceInfo;
-    fn fetch_tile_set(&mut self) -> TileSet;
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile;
     fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotTile;
     fn fetch_slot_meta_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SlotMetaTile;
@@ -141,9 +140,6 @@ pub trait DataSourceMut {
 impl<T: DataSource> DataSourceMut for T {
     fn fetch_info(&mut self) -> DataSourceInfo {
         DataSource::fetch_info(self)
-    }
-    fn fetch_tile_set(&mut self) -> TileSet {
-        DataSource::fetch_tile_set(self)
     }
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile {
         DataSource::fetch_summary_tile(self, entry_id, tile_id)

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 
 use url::Url;
 
-use crate::data::{DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID, TileSet};
+use crate::data::{DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID};
 use crate::deferred_data::DeferredDataSource;
 use crate::http::fetch::{fetch, DataSourceResponse};
 use crate::http::schema::TileRequestRef;
@@ -20,7 +20,6 @@ pub struct HTTPClientDataSource {
     pub baseurl: Url,
     pub client: Client,
     infos: Arc<Mutex<Vec<DataSourceInfo>>>,
-    tile_sets: Arc<Mutex<Vec<TileSet>>>,
     summary_tiles: Arc<Mutex<Vec<SummaryTile>>>,
     slot_tiles: Arc<Mutex<Vec<SlotTile>>>,
     slot_meta_tiles: Arc<Mutex<Vec<SlotMetaTile>>>,
@@ -32,7 +31,6 @@ impl HTTPClientDataSource {
             baseurl,
             client: ClientBuilder::new().build().unwrap(),
             infos: Arc::new(Mutex::new(Vec::new())),
-            tile_sets: Arc::new(Mutex::new(Vec::new())),
             summary_tiles: Arc::new(Mutex::new(Vec::new())),
             slot_tiles: Arc::new(Mutex::new(Vec::new())),
             slot_meta_tiles: Arc::new(Mutex::new(Vec::new())),
@@ -61,7 +59,7 @@ impl HTTPClientDataSource {
 
 impl DeferredDataSource for HTTPClientDataSource {
     fn fetch_info(&mut self) {
-        let url = self.baseurl.join("/info").expect("invalid baseurl");
+        let url = self.baseurl.join("info").expect("invalid baseurl");
         self.request::<DataSourceInfo>(url, self.infos.clone());
     }
 
@@ -69,20 +67,11 @@ impl DeferredDataSource for HTTPClientDataSource {
         std::mem::take(&mut self.infos.lock().unwrap())
     }
 
-    fn fetch_tile_set(&mut self) {
-        let url = self.baseurl.join("/tile_set").expect("invalid baseurl");
-        self.request::<TileSet>(url, self.tile_sets.clone());
-    }
-
-    fn get_tile_sets(&mut self) -> Vec<TileSet> {
-        std::mem::take(&mut self.tile_sets.lock().unwrap())
-    }
-
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID) {
         let req = TileRequestRef { entry_id, tile_id };
         let url = self
             .baseurl
-            .join("/summary_tile/")
+            .join("summary_tile/")
             .and_then(|u| u.join(&req.to_slug()))
             .expect("invalid baseurl");
         self.request::<SummaryTile>(url, self.summary_tiles.clone());
@@ -96,7 +85,7 @@ impl DeferredDataSource for HTTPClientDataSource {
         let req = TileRequestRef { entry_id, tile_id };
         let url = self
             .baseurl
-            .join("/slot_tile/")
+            .join("slot_tile/")
             .and_then(|u| u.join(&req.to_slug()))
             .expect("invalid baseurl");
         self.request::<SlotTile>(url, self.slot_tiles.clone());
@@ -110,7 +99,7 @@ impl DeferredDataSource for HTTPClientDataSource {
         let req = TileRequestRef { entry_id, tile_id };
         let url = self
             .baseurl
-            .join("/slot_meta_tile/")
+            .join("slot_meta_tile/")
             .and_then(|u| u.join(&req.to_slug()))
             .expect("invalid baseurl");
         self.request::<SlotMetaTile>(url, self.slot_meta_tiles.clone());

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -26,12 +26,6 @@ async fn fetch_info(state: web::Data<AppState>) -> Result<impl Responder> {
     Ok(web::Json(result))
 }
 
-#[get("/tile_set")]
-async fn fetch_tile_set(state: web::Data<AppState>) -> Result<impl Responder> {
-    let result = state.data_source.fetch_tile_set();
-    Ok(web::Json(result))
-}
-
 #[get("/summary_tile/{entry_id}/{tile_id}")]
 async fn fetch_summary_tile(
     req: web::Path<TileRequestPath>,
@@ -108,7 +102,6 @@ impl DataSourceHTTPServer {
                 .wrap(cors)
                 .app_data(state.clone())
                 .service(fetch_info)
-                .service(fetch_tile_set)
                 .service(fetch_summary_tile)
                 .service(fetch_slot_tile)
                 .service(fetch_slot_meta_tile)

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,11 +260,8 @@ impl DataSourceMut for RandomDataSource {
         DataSourceInfo {
             entry_info: self.entry_info().clone(),
             interval: self.interval(),
+            tile_set: TileSet::default(),
         }
-    }
-
-    fn fetch_tile_set(&mut self) -> TileSet {
-        TileSet::default()
     }
 
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID) -> SummaryTile {


### PR DESCRIPTION
Modifies DataSource interface to fold TileSet into DataSourceInfo to save one request and simplify initialization.