### PR TITLE
Use common log prefix for window title

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1193,7 +1193,7 @@ impl SearchState {
         if !self.result_cache.contains_key(entry.entry_id()) {
             self.result_cache
                 .entry(entry.entry_id().clone())
-                .or_insert_with(BTreeMap::new);
+                .or_default();
         }
 
         // Always recurse into tiles, because results can be fetched
@@ -1215,7 +1215,7 @@ impl SearchState {
             .and_modify(|_| {
                 result = false;
             })
-            .or_insert_with(BTreeMap::new);
+            .or_default();
         result
     }
 
@@ -1251,13 +1251,8 @@ impl SearchState {
             let level1_index = entry_id.slot_index(1).unwrap();
             let level2_index = entry_id.slot_index(2).unwrap();
 
-            let level0_subtree = self
-                .entry_tree
-                .entry(level0_index)
-                .or_insert_with(BTreeMap::new);
-            let level1_subtree = level0_subtree
-                .entry(level1_index)
-                .or_insert_with(BTreeSet::new);
+            let level0_subtree = self.entry_tree.entry(level0_index).or_default();
+            let level1_subtree = level0_subtree.entry(level1_index).or_default();
             level1_subtree.insert(level2_index);
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
+use std::path::Path;
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
@@ -2443,8 +2444,28 @@ pub fn start(data_sources: Vec<Box<dyn DeferredDataSource>>) {
     env_logger::try_init().unwrap_or(()); // Log to stderr (if you run with `RUST_LOG=debug`).
 
     let native_options = eframe::NativeOptions::default();
+
+    let mut paths = BTreeSet::new();
+    let arguments: Vec<String> = std::env::args().collect();
+    for argument in &arguments[1..] {
+        if !argument.starts_with("--") {
+            let path = Path::new(&argument)
+                .parent()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+            paths.insert(path);
+        }
+    }
+    let app_name = if paths.len() == 1 {
+        paths.pop_last().unwrap()
+    } else {
+        String::from("Legion Prof")
+    };
+
     eframe::run_native(
-        "Legion Prof",
+        &app_name,
         native_options,
         Box::new(|cc| Box::new(ProfApp::new(cc, data_sources))),
     )


### PR DESCRIPTION
This PR adds support to attempt to extract a common path prefix for log files provided on the command line, to use for the window title. If a common prefix is not determinable, the default "Legion Prof" is retained. cc @lightsighter 

This PR also applies some some fixes advised by clippy regarding `or_default`.

cc @elliottslaughter is there a more robust rust solution for pruning command line options than this?
```rust
if !argument.starts_with("--") { ... }
```

## Usage 

Invoked with 
```sh
RUST_BACKTRACE=1 target/debug/legion_prof --view ~/work/proflogs/231034/*.prof
```
produces:

<img width="872" alt="Screenshot 2023-10-09 at 14 26 48" src="https://github.com/StanfordLegion/prof-viewer/assets/1078448/44b4b969-9a3a-4ebb-8d7e-333a7d415994">
