### PR TITLE
Allow ESC to reset UI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1769,7 +1769,6 @@ impl ProfApp {
     fn reset_ui(cx: &mut Context, windows: &mut [Window]) {
         cx.show_controls = false;
         for window in windows.iter_mut() {
-            window.config.kind_filter.clear();
             window.config.items_selected.clear();
         }
     }


### PR DESCRIPTION
This PR adds support for having the ESC key reset the UI. cc @lightsighter 

Reset includes:

* clearing controls help
* clearing profile filter selections
* clearing any hovers generated by clicking spans

This PR also applies some clippy fixes related to `or_default`.

cc @elliottslaughter if there is some better approach that does not requires passing the windows list through, please let me know. 