### PR TITLE
Add option for whole-word search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "percentage",
  "rand",
  "rayon",
+ "regex",
  "reqwest",
  "serde",
  "url",
@@ -1892,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
@@ -2539,9 +2540,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2550,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ client = ["dep:reqwest", "dep:url"]
 server = ["dep:actix-cors", "dep:actix-web"]
 
 [dependencies]
-regex = "1.10.0"
 percentage = "0.1.0"
 egui = "0.22.0"
 egui_extras = "0.22.0"
@@ -32,6 +31,8 @@ bytes = "1" # for reqwest binary data
 rand = { version = "0.8" }
 # transitive depedency, required for rand to support wasm
 getrandom = { version = "0.2", features = ["js"] }
+
+regex = "1.10.0"
 
 
 # client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ client = ["dep:reqwest", "dep:url"]
 server = ["dep:actix-cors", "dep:actix-web"]
 
 [dependencies]
+regex = "1.10.0"
 percentage = "0.1.0"
 egui = "0.22.0"
 egui_extras = "0.22.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -111,9 +111,9 @@ struct SearchState {
     // Search parameters
     query: String,
     last_query: String,
-    whole_word: bool,
     search_field: FieldID,
     last_search_field: FieldID,
+    whole_word: bool,
     last_whole_word: bool,
     last_word_regex: Option<Regex>,
     include_collapsed_entries: bool,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1187,10 +1187,10 @@ impl SearchState {
 
     fn is_string_match(&self, s: &str) -> bool {
         if self.whole_word {
-            match &self.last_word_regex {
-                Some(regex) => regex.is_match(s),
-                _ => false,
-            }
+            let Some(regex) = &self.last_word_regex else {
+                unreachable!();
+            };
+            regex.is_match(s)
         } else {
             s.contains(&self.query)
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1143,10 +1143,6 @@ impl SearchState {
         if self.query != self.last_query {
             invalidate = true;
             self.last_query = self.query.clone();
-            if self.whole_word {
-                let regex_string = format!("\\b{}\\b", escape(&self.query));
-                self.last_word_regex = Some(Regex::new(regex_string.as_str()).unwrap());
-            }
         }
 
         // Invalidate when the search field changes.
@@ -1159,10 +1155,6 @@ impl SearchState {
         if self.whole_word != self.last_whole_word {
             invalidate = true;
             self.last_whole_word = self.whole_word;
-            if self.whole_word {
-                let regex_string = format!("\\b{}\\b", escape(&self.query));
-                self.last_word_regex = Some(Regex::new(regex_string.as_str()).unwrap());
-            }
         }
 
         // Invalidate when EXCLUDING collapsed entries. (I.e., because the
@@ -1181,6 +1173,11 @@ impl SearchState {
         }
 
         if invalidate {
+            if self.whole_word {
+                let regex_string = format!("\\b{}\\b", escape(&self.query));
+                self.last_word_regex = Some(Regex::new(&regex_string).unwrap());
+            }
+
             self.clear();
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -111,13 +111,13 @@ struct SearchState {
     // Search parameters
     query: String,
     last_query: String,
-    last_word_regex: Option<Regex>,
-    include_collapsed_entries: bool,
     whole_word: bool,
-    last_whole_word: bool,
-    last_include_collapsed_entries: bool,
     search_field: FieldID,
     last_search_field: FieldID,
+    last_whole_word: bool,
+    last_word_regex: Option<Regex>,
+    include_collapsed_entries: bool,
+    last_include_collapsed_entries: bool,
     last_view_interval: Option<Interval>,
 
     // Cache of matching items
@@ -1115,13 +1115,13 @@ impl SearchState {
 
             query: "".to_owned(),
             last_query: "".to_owned(),
-            last_word_regex: None,
-            include_collapsed_entries: false,
-            whole_word: false,
-            last_whole_word: false,
-            last_include_collapsed_entries: false,
             search_field: title_id,
             last_search_field: title_id,
+            whole_word: false,
+            last_whole_word: false,
+            last_word_regex: None,
+            include_collapsed_entries: false,
+            last_include_collapsed_entries: false,
             last_view_interval: None,
 
             result_set: BTreeSet::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1176,11 +1176,12 @@ impl SearchState {
     }
 
     fn is_string_match(&self, s: &str) -> bool {
-        match self.whole_word {
-            true => Regex::new(format!("\\b{}\\b", self.query).as_str())
+        if self.whole_word {
+            Regex::new(format!("\\b{}\\b", self.query).as_str())
                 .unwrap()
-                .is_match(s),
-            false => s.contains(&self.query),
+                .is_match(s)
+        } else {
+            s.contains(&self.query)
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use egui::{
 };
 use egui_extras::{Column, TableBuilder};
 use percentage::{Percentage, PercentageInteger};
-use regex::Regex;
+use regex::{Regex, escape};
 use serde::{Deserialize, Serialize};
 
 use crate::data::{
@@ -1177,7 +1177,7 @@ impl SearchState {
 
     fn is_string_match(&self, s: &str) -> bool {
         if self.whole_word {
-            Regex::new(format!("\\b{}\\b", self.query).as_str())
+            Regex::new(format!("\\b{}\\b", escape(&self.query)).as_str())
                 .unwrap()
                 .is_match(s)
         } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use egui::{
 };
 use egui_extras::{Column, TableBuilder};
 use percentage::{Percentage, PercentageInteger};
-use regex::{Regex, escape};
+use regex::{escape, Regex};
 use serde::{Deserialize, Serialize};
 
 use crate::data::{

--- a/src/app.rs
+++ b/src/app.rs
@@ -1602,7 +1602,7 @@ impl Window {
         });
         ui.checkbox(
             &mut self.config.search_state.whole_word,
-            "whole-word matches only",
+            "Match whole words only",
         );
         ui.checkbox(
             &mut self.config.search_state.include_collapsed_entries,


### PR DESCRIPTION
This PR adds checkbox option to the search that supports only returning results for whole-word matches. 

* closes #31 

cc @elliottslaughter @lightsighter 

---

Searching for "64" with the whole-word option unchecked yields many results, including ones with 64 in the middle of words:

<img width="782" alt="Screenshot 2023-10-12 at 12 17 06" src="https://github.com/StanfordLegion/prof-viewer/assets/1078448/8d415ee7-2178-47c4-bf68-b6e636a012e6">

Checking the whole-word option updates to fewer results that only have "64" as an entire word:

<img width="823" alt="Screenshot 2023-10-12 at 12 16 41" src="https://github.com/StanfordLegion/prof-viewer/assets/1078448/2ba2d544-5944-4109-ba9b-5599422177b3">
