### PR TITLE
[WIP] Plumbing for source locator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +1811,7 @@ dependencies = [
  "egui_extras",
  "env_logger",
  "getrandom",
+ "itertools",
  "log",
  "percentage",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = { version = "0.8" }
 # transitive depedency, required for rand to support wasm
 getrandom = { version = "0.2", features = ["js"] }
 
+itertools = "0.11.0"
 percentage = "0.1.0"
 regex = "1.10.0"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2544,11 +2544,11 @@ pub fn start(mut data_sources: Vec<Box<dyn DeferredDataSource>>) {
 
     let app_name = if data_sources.len() == 1 {
         match data_sources[0].fetch_description().source_locator {
-            Some(source_locator) => source_locator,
-            _ => String::from("Legion Prof"),
+            Some(source_locator) => format!("{source_locator} - Legion Prof"),
+            _ => String::from("Unknown Data Source - Legion Prof"),
         }
     } else {
-        String::from("Legion Prof")
+        String::from("Unknone Data Source - Legion Prof")
     };
 
     let native_options = eframe::NativeOptions::default();

--- a/src/app.rs
+++ b/src/app.rs
@@ -2543,7 +2543,7 @@ pub fn start(mut data_sources: Vec<Box<dyn DeferredDataSource>>) {
     env_logger::try_init().unwrap_or(()); // Log to stderr (if you run with `RUST_LOG=debug`).
 
     let app_name = if data_sources.len() == 1 {
-        match data_sources[0].get_description().source_locator {
+        match data_sources[0].fetch_description().source_locator {
             Some(source_locator) => source_locator,
             _ => String::from("Legion Prof"),
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2539,17 +2539,22 @@ impl UiExtra for egui::Ui {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn start(mut data_sources: Vec<Box<dyn DeferredDataSource>>) {
+pub fn start(data_sources: Vec<Box<dyn DeferredDataSource>>) {
     env_logger::try_init().unwrap_or(()); // Log to stderr (if you run with `RUST_LOG=debug`).
 
-    let app_name = if data_sources.len() == 1 {
-        match data_sources[0].fetch_description().source_locator {
-            Some(source_locator) => format!("{source_locator} - Legion Prof"),
-            _ => "Unknown Data Source - Legion Prof".to_string(),
-        }
-    } else {
-        "Unknown Data Source - Legion Prof".to_string()
+    let all_locators = data_sources.iter().fold(Vec::new(), |acc, x| {
+        acc.into_iter()
+            .chain(x.fetch_description().source_locator)
+            .collect()
+    });
+
+    let locator = match &all_locators[..] {
+        [] => "No data source".to_string(),
+        [x] => x.to_string(),
+        [x, ..] => format!("{} and {} other sources", x, all_locators.len() - 1),
     };
+
+    let app_name = format!("{locator} - Legion Prof");
 
     let native_options = eframe::NativeOptions::default();
     eframe::run_native(

--- a/src/app.rs
+++ b/src/app.rs
@@ -2544,11 +2544,10 @@ impl UiExtra for egui::Ui {
 pub fn start(data_sources: Vec<Box<dyn DeferredDataSource>>) {
     env_logger::try_init().unwrap_or(()); // Log to stderr (if you run with `RUST_LOG=debug`).
 
-    let all_locators = data_sources.iter().fold(Vec::new(), |acc, x| {
-        acc.into_iter()
-            .chain(x.fetch_description().source_locator)
-            .collect()
-    });
+    let all_locators = data_sources
+        .iter()
+        .flat_map(|x| x.fetch_description().source_locator)
+        .collect::<Vec<_>>();
 
     let unique_locators = all_locators.into_iter().unique().collect_vec();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2545,10 +2545,10 @@ pub fn start(mut data_sources: Vec<Box<dyn DeferredDataSource>>) {
     let app_name = if data_sources.len() == 1 {
         match data_sources[0].fetch_description().source_locator {
             Some(source_locator) => format!("{source_locator} - Legion Prof"),
-            _ => String::from("Unknown Data Source - Legion Prof"),
+            _ => "Unknown Data Source - Legion Prof".to_string(),
         }
     } else {
-        String::from("Unknone Data Source - Legion Prof")
+        "Unknown Data Source - Legion Prof".to_string()
     };
 
     let native_options = eframe::NativeOptions::default();

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use egui::{
     Align2, Color32, NumExt, Pos2, Rect, RichText, ScrollArea, Slider, Stroke, TextStyle, Vec2,
 };
 use egui_extras::{Column, TableBuilder};
+#[cfg(not(target_arch = "wasm32"))]
 use itertools::Itertools;
 use percentage::{Percentage, PercentageInteger};
 use regex::{escape, Regex};

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use egui::{
     Align2, Color32, NumExt, Pos2, Rect, RichText, ScrollArea, Slider, Stroke, TextStyle, Vec2,
 };
 use egui_extras::{Column, TableBuilder};
+use itertools::Itertools;
 use percentage::{Percentage, PercentageInteger};
 use regex::{escape, Regex};
 use serde::{Deserialize, Serialize};
@@ -2548,10 +2549,12 @@ pub fn start(data_sources: Vec<Box<dyn DeferredDataSource>>) {
             .collect()
     });
 
-    let locator = match &all_locators[..] {
+    let unique_locators = all_locators.into_iter().unique().collect_vec();
+
+    let locator = match &unique_locators[..] {
         [] => "No data source".to_string(),
         [x] => x.to_string(),
-        [x, ..] => format!("{} and {} other sources", x, all_locators.len() - 1),
+        [x, ..] => format!("{} and {} other sources", x, unique_locators.len() - 1),
     };
 
     let app_name = format!("{locator} - Legion Prof");

--- a/src/app.rs
+++ b/src/app.rs
@@ -2539,12 +2539,21 @@ impl UiExtra for egui::Ui {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn start(data_sources: Vec<Box<dyn DeferredDataSource>>) {
+pub fn start(mut data_sources: Vec<Box<dyn DeferredDataSource>>) {
     env_logger::try_init().unwrap_or(()); // Log to stderr (if you run with `RUST_LOG=debug`).
+
+    let app_name = if data_sources.len() == 1 {
+        match data_sources[0].get_description().source_locator {
+            Some(source_locator) => source_locator,
+            _ => String::from("Legion Prof"),
+        }
+    } else {
+        String::from("Legion Prof")
+    };
 
     let native_options = eframe::NativeOptions::default();
     eframe::run_native(
-        "Legion Prof",
+        &app_name,
         native_options,
         Box::new(|cc| Box::new(ProfApp::new(cc, data_sources))),
     )

--- a/src/data.rs
+++ b/src/data.rs
@@ -206,7 +206,13 @@ pub struct SlotMetaTile {
     pub data: SlotMetaTileData,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DataSourceDescription {
+    pub source_locator: Option<String>,
+}
+
 pub trait DataSource {
+    fn fetch_description(&self) -> DataSourceDescription;
     fn fetch_info(&self) -> DataSourceInfo;
     fn fetch_summary_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SummaryTile;
     fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SlotTile;
@@ -215,6 +221,7 @@ pub trait DataSource {
 }
 
 pub trait DataSourceMut {
+    fn fetch_description(&mut self) -> DataSourceDescription;
     fn fetch_info(&mut self) -> DataSourceInfo;
     fn fetch_summary_tile(
         &mut self,
@@ -232,6 +239,9 @@ pub trait DataSourceMut {
 }
 
 impl<T: DataSource> DataSourceMut for T {
+    fn fetch_description(&mut self) -> DataSourceDescription {
+        DataSource::fetch_description(self)
+    }
     fn fetch_info(&mut self) -> DataSourceInfo {
         DataSource::fetch_info(self)
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -208,7 +208,7 @@ pub struct SlotMetaTile {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DataSourceDescription {
-    pub source_locator: Option<String>,
+    pub source_locator: Vec<String>,
 }
 
 pub trait DataSource {
@@ -221,7 +221,7 @@ pub trait DataSource {
 }
 
 pub trait DataSourceMut {
-    fn fetch_description(&mut self) -> DataSourceDescription;
+    fn fetch_description(&self) -> DataSourceDescription;
     fn fetch_info(&mut self) -> DataSourceInfo;
     fn fetch_summary_tile(
         &mut self,
@@ -239,7 +239,7 @@ pub trait DataSourceMut {
 }
 
 impl<T: DataSource> DataSourceMut for T {
-    fn fetch_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&self) -> DataSourceDescription {
         DataSource::fetch_description(self)
     }
     fn fetch_info(&mut self) -> DataSourceInfo {

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -1,5 +1,6 @@
 use crate::data::{
-    DataSourceDescription, DataSourceInfo, DataSourceMut, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
+    DataSourceDescription, DataSourceInfo, DataSourceMut, EntryID, SlotMetaTile, SlotTile,
+    SummaryTile, TileID,
 };
 
 pub trait DeferredDataSource {
@@ -36,9 +37,7 @@ impl<T: DataSourceMut> DeferredDataSourceWrapper<T> {
 }
 
 impl<T: DataSourceMut> DeferredDataSource for DeferredDataSourceWrapper<T> {
-    fn fetch_description(&mut self) {
-
-    }
+    fn fetch_description(&mut self) {}
 
     fn get_description(&mut self) -> DataSourceDescription {
         self.data_source.fetch_description()

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -4,8 +4,7 @@ use crate::data::{
 };
 
 pub trait DeferredDataSource {
-    fn fetch_description(&mut self);
-    fn get_description(&mut self) -> DataSourceDescription;
+    fn fetch_description(&mut self) -> DataSourceDescription;
     fn fetch_info(&mut self);
     fn get_infos(&mut self) -> Vec<DataSourceInfo>;
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool);
@@ -37,9 +36,7 @@ impl<T: DataSourceMut> DeferredDataSourceWrapper<T> {
 }
 
 impl<T: DataSourceMut> DeferredDataSource for DeferredDataSourceWrapper<T> {
-    fn fetch_description(&mut self) {}
-
-    fn get_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&mut self) -> DataSourceDescription {
         self.data_source.fetch_description()
     }
 
@@ -111,15 +108,8 @@ impl<T: DeferredDataSource> CountingDeferredDataSource<T> {
 }
 
 impl<T: DeferredDataSource> DeferredDataSource for CountingDeferredDataSource<T> {
-    fn fetch_description(&mut self) {
-        self.start_request();
+    fn fetch_description(&mut self) -> DataSourceDescription {
         self.data_source.fetch_description()
-    }
-
-    fn get_description(&mut self) -> DataSourceDescription {
-        let result = self.data_source.get_description();
-        self.outstanding_requests -= 1;
-        result
     }
 
     fn fetch_info(&mut self) {
@@ -165,12 +155,8 @@ impl<T: DeferredDataSource> DeferredDataSource for CountingDeferredDataSource<T>
 }
 
 impl DeferredDataSource for Box<dyn DeferredDataSource> {
-    fn fetch_description(&mut self) {
+    fn fetch_description(&mut self) -> DataSourceDescription {
         self.as_mut().fetch_description()
-    }
-
-    fn get_description(&mut self) -> DataSourceDescription {
-        self.as_mut().get_description()
     }
 
     fn fetch_info(&mut self) {

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -4,7 +4,7 @@ use crate::data::{
 };
 
 pub trait DeferredDataSource {
-    fn fetch_description(&mut self) -> DataSourceDescription;
+    fn fetch_description(&self) -> DataSourceDescription;
     fn fetch_info(&mut self);
     fn get_infos(&mut self) -> Vec<DataSourceInfo>;
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool);
@@ -36,7 +36,7 @@ impl<T: DataSourceMut> DeferredDataSourceWrapper<T> {
 }
 
 impl<T: DataSourceMut> DeferredDataSource for DeferredDataSourceWrapper<T> {
-    fn fetch_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&self) -> DataSourceDescription {
         self.data_source.fetch_description()
     }
 
@@ -108,7 +108,7 @@ impl<T: DeferredDataSource> CountingDeferredDataSource<T> {
 }
 
 impl<T: DeferredDataSource> DeferredDataSource for CountingDeferredDataSource<T> {
-    fn fetch_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&self) -> DataSourceDescription {
         self.data_source.fetch_description()
     }
 
@@ -155,8 +155,8 @@ impl<T: DeferredDataSource> DeferredDataSource for CountingDeferredDataSource<T>
 }
 
 impl DeferredDataSource for Box<dyn DeferredDataSource> {
-    fn fetch_description(&mut self) -> DataSourceDescription {
-        self.as_mut().fetch_description()
+    fn fetch_description(&self) -> DataSourceDescription {
+        self.as_ref().fetch_description()
     }
 
     fn fetch_info(&mut self) {

--- a/src/file_data.rs
+++ b/src/file_data.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::data::{
-    DataSource, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
+    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
 };
 use crate::http::schema::TileRequestRef;
 
@@ -30,6 +30,9 @@ impl FileDataSource {
 }
 
 impl DataSource for FileDataSource {
+    fn fetch_description(&self) -> DataSourceDescription {
+        DataSourceDescription { source_locator: None }
+    }
     fn fetch_info(&self) -> DataSourceInfo {
         let path = self.basedir.join("info");
         self.read_file::<DataSourceInfo>(&path)

--- a/src/file_data.rs
+++ b/src/file_data.rs
@@ -33,7 +33,7 @@ impl FileDataSource {
 impl DataSource for FileDataSource {
     fn fetch_description(&self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: Some(String::from(self.basedir.to_string_lossy())),
+            source_locator: vec![String::from(self.basedir.to_string_lossy())],
         }
     }
     fn fetch_info(&self) -> DataSourceInfo {

--- a/src/file_data.rs
+++ b/src/file_data.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::data::{
-    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
+    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile,
+    SummaryTile, TileID,
 };
 use crate::http::schema::TileRequestRef;
 
@@ -31,7 +32,9 @@ impl FileDataSource {
 
 impl DataSource for FileDataSource {
     fn fetch_description(&self) -> DataSourceDescription {
-        DataSourceDescription { source_locator: None }
+        DataSourceDescription {
+            source_locator: None,
+        }
     }
     fn fetch_info(&self) -> DataSourceInfo {
         let path = self.basedir.join("info");

--- a/src/file_data.rs
+++ b/src/file_data.rs
@@ -33,7 +33,7 @@ impl FileDataSource {
 impl DataSource for FileDataSource {
     fn fetch_description(&self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: None,
+            source_locator: Some(String::from(self.basedir.to_string_lossy())),
         }
     }
     fn fetch_info(&self) -> DataSourceInfo {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -64,9 +64,9 @@ impl HTTPClientDataSource {
 }
 
 impl DeferredDataSource for HTTPClientDataSource {
-    fn fetch_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: Some(self.baseurl.to_string()),
+            source_locator: vec![self.baseurl.to_string()],
         }
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 
 use url::Url;
 
-use crate::data::{DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID};
+use crate::data::{DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID};
 use crate::deferred_data::DeferredDataSource;
 use crate::http::fetch::{fetch, DataSourceResponse};
 use crate::http::schema::TileRequestRef;
@@ -62,6 +62,14 @@ impl HTTPClientDataSource {
 }
 
 impl DeferredDataSource for HTTPClientDataSource {
+    fn fetch_description(&mut self) {
+
+    }
+
+    fn get_description(&mut self) -> DataSourceDescription {
+        DataSourceDescription {source_locator: None}
+    }
+
     fn fetch_info(&mut self) {
         let url = self.baseurl.join("info").expect("invalid baseurl");
         self.request::<DataSourceInfo>(url, self.infos.clone());

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -64,11 +64,9 @@ impl HTTPClientDataSource {
 }
 
 impl DeferredDataSource for HTTPClientDataSource {
-    fn fetch_description(&mut self) {}
-
-    fn get_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&mut self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: None,
+            source_locator: Some(self.baseurl.to_string()),
         }
     }
 

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -13,7 +13,9 @@ use serde::Deserialize;
 
 use url::Url;
 
-use crate::data::{DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID};
+use crate::data::{
+    DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
+};
 use crate::deferred_data::DeferredDataSource;
 use crate::http::fetch::{fetch, DataSourceResponse};
 use crate::http::schema::TileRequestRef;
@@ -62,12 +64,12 @@ impl HTTPClientDataSource {
 }
 
 impl DeferredDataSource for HTTPClientDataSource {
-    fn fetch_description(&mut self) {
-
-    }
+    fn fetch_description(&mut self) {}
 
     fn get_description(&mut self) -> DataSourceDescription {
-        DataSourceDescription {source_locator: None}
+        DataSourceDescription {
+            source_locator: None,
+        }
     }
 
     fn fetch_info(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,9 +268,9 @@ impl RandomDataSource {
 }
 
 impl DataSourceMut for RandomDataSource {
-    fn fetch_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: Some(String::from("Random Data Source")),
+            source_locator: vec![String::from("Random Data Source")],
         }
     }
     fn fetch_info(&mut self) -> DataSourceInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ impl RandomDataSource {
 impl DataSourceMut for RandomDataSource {
     fn fetch_description(&mut self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: None,
+            source_locator: Some(String::from("Random Data Source")),
         }
     }
     fn fetch_info(&mut self) -> DataSourceInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 use std::collections::BTreeMap;
 
 use legion_prof_viewer::data::{
-    DataSourceInfo, DataSourceMut, EntryID, EntryInfo, Field, FieldID, FieldSchema, Item, ItemMeta,
+    DataSourceDescription, DataSourceInfo, DataSourceMut, EntryID, EntryInfo, Field, FieldID, FieldSchema, Item, ItemMeta,
     ItemUID, SlotMetaTile, SlotMetaTileData, SlotTile, SlotTileData, SummaryTile, SummaryTileData,
     TileID, TileSet, UtilPoint,
 };
@@ -268,6 +268,9 @@ impl RandomDataSource {
 }
 
 impl DataSourceMut for RandomDataSource {
+    fn fetch_description(&mut self) -> DataSourceDescription {
+        DataSourceDescription { source_locator: None }
+    }
     fn fetch_info(&mut self) -> DataSourceInfo {
         self.info.clone()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use rand::Rng;
 use std::collections::BTreeMap;
 
 use legion_prof_viewer::data::{
-    DataSourceDescription, DataSourceInfo, DataSourceMut, EntryID, EntryInfo, Field, FieldID, FieldSchema, Item, ItemMeta,
-    ItemUID, SlotMetaTile, SlotMetaTileData, SlotTile, SlotTileData, SummaryTile, SummaryTileData,
-    TileID, TileSet, UtilPoint,
+    DataSourceDescription, DataSourceInfo, DataSourceMut, EntryID, EntryInfo, Field, FieldID,
+    FieldSchema, Item, ItemMeta, ItemUID, SlotMetaTile, SlotMetaTileData, SlotTile, SlotTileData,
+    SummaryTile, SummaryTileData, TileID, TileSet, UtilPoint,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -269,7 +269,9 @@ impl RandomDataSource {
 
 impl DataSourceMut for RandomDataSource {
     fn fetch_description(&mut self) -> DataSourceDescription {
-        DataSourceDescription { source_locator: None }
+        DataSourceDescription {
+            source_locator: None,
+        }
     }
     fn fetch_info(&mut self) -> DataSourceInfo {
         self.info.clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ impl RandomDataSource {
 impl DataSourceMut for RandomDataSource {
     fn fetch_description(&self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: vec![String::from("Random Data Source")],
+            source_locator: vec!["Random Data Source".to_string()],
         }
     }
     fn fetch_info(&mut self) -> DataSourceInfo {

--- a/src/merge_data.rs
+++ b/src/merge_data.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 
 use crate::data::{
-    DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, ItemLink, ItemUID, SlotMetaTile,
-    SlotTile, SummaryTile, TileID,
+    DataSourceDescription, DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, ItemLink,
+    ItemUID, SlotMetaTile, SlotTile, SummaryTile, TileID,
 };
 use crate::deferred_data::DeferredDataSource;
 use crate::timestamp::Interval;
@@ -192,6 +192,16 @@ impl MergeDeferredDataSource {
 }
 
 impl DeferredDataSource for MergeDeferredDataSource {
+    fn fetch_description(&self) -> DataSourceDescription {
+        DataSourceDescription {
+            source_locator: self.data_sources.iter().fold(Vec::new(), |acc, x| {
+                acc.into_iter()
+                    .chain(x.fetch_description().source_locator)
+                    .collect()
+            }),
+        }
+    }
+
     fn fetch_info(&mut self) {
         for data_source in &mut self.data_sources {
             data_source.fetch_info();

--- a/src/merge_data.rs
+++ b/src/merge_data.rs
@@ -194,11 +194,11 @@ impl MergeDeferredDataSource {
 impl DeferredDataSource for MergeDeferredDataSource {
     fn fetch_description(&self) -> DataSourceDescription {
         DataSourceDescription {
-            source_locator: self.data_sources.iter().fold(Vec::new(), |acc, x| {
-                acc.into_iter()
-                    .chain(x.fetch_description().source_locator)
-                    .collect()
-            }),
+            source_locator: self
+                .data_sources
+                .iter()
+                .flat_map(|x| x.fetch_description().source_locator)
+                .collect::<Vec<_>>(),
         }
     }
 

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::data::{
-    DataSource, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
+    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
 };
 use crate::deferred_data::DeferredDataSource;
 
@@ -26,6 +26,14 @@ impl<T: DataSource + Send + Sync + 'static> ParallelDeferredDataSource<T> {
 }
 
 impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDeferredDataSource<T> {
+    fn fetch_description(&mut self) {
+
+    }
+
+    fn get_description(&mut self) -> DataSourceDescription {
+        self.data_source.fetch_description()
+    }
+
     fn fetch_info(&mut self) {
         let data_source = self.data_source.clone();
         let infos = self.infos.clone();

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -27,7 +27,7 @@ impl<T: DataSource + Send + Sync + 'static> ParallelDeferredDataSource<T> {
 }
 
 impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDeferredDataSource<T> {
-    fn fetch_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&self) -> DataSourceDescription {
         self.data_source.fetch_description()
     }
 

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -1,7 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use crate::data::{
-    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile, SummaryTile, TileID,
+    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile,
+    SummaryTile, TileID,
 };
 use crate::deferred_data::DeferredDataSource;
 
@@ -26,9 +27,7 @@ impl<T: DataSource + Send + Sync + 'static> ParallelDeferredDataSource<T> {
 }
 
 impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDeferredDataSource<T> {
-    fn fetch_description(&mut self) {
-
-    }
+    fn fetch_description(&mut self) {}
 
     fn get_description(&mut self) -> DataSourceDescription {
         self.data_source.fetch_description()

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -27,9 +27,7 @@ impl<T: DataSource + Send + Sync + 'static> ParallelDeferredDataSource<T> {
 }
 
 impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDeferredDataSource<T> {
-    fn fetch_description(&mut self) {}
-
-    fn get_description(&mut self) -> DataSourceDescription {
+    fn fetch_description(&mut self) -> DataSourceDescription {
         self.data_source.fetch_description()
     }
 


### PR DESCRIPTION
This PR adds a new `DataSourceDescription` struct with a `source_locator` attribute that can be displayed as the app title when present. A corresponding PR will be needed in the frontend to actually compute a common prefix and add it to `StateDataSource`. 

The PR resulted from a good amount of just following the compiler and making things fit, but I have doubts about some of the changes, comments inline @elliottslaughter.