### PR TITLE
Fix vertical scroll to item when row is unknown, and pop up window with item details

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@
 - [X] Horizontal pan (using keyboard arrow keys)
 - [x] Report both field IDs and field names
 - [x] On each instance box, add a "zoom to item" button to the "initiator" (i.e. the task that created that instance?)
+- [x] When user clicks "zoom to item", e.g. on an instance listed in a task box, also open that new item's popup
 - [ ] Horizontal pan (via click and drag, touchpad, or horizontal scroll wheel)
 - [ ] Allow horizontal panning past the start/end of the profile, but not so much that none of the actual profile is visible anymore. Out-of-bounds areas should get a different background color.
 - [ ] Keyboard bindings (e.g., arrow keys to select panels, space bar to toggle expand/collapse, ESC key to close popups)
@@ -44,7 +45,6 @@
   - different line color
   - saturate all other boxes except the highlighted one (as happens for search)
 
-- [ ] When user clicks "zoom to item", e.g. on an instance listed in a task box, also open that new item's popup
 - [ ] Have the tooltip box wrap text / scroll vertically if the contents are too long,
       e.g. if we're trying to show full backtraces on provenance, or there's many field names to list
 - [ ] Color instances using a heat map based on size

--- a/src/app.rs
+++ b/src/app.rs
@@ -1453,6 +1453,12 @@ impl Window {
         self.panel.expand_slot(entry_id, 0);
     }
 
+    fn inflate_meta(&mut self, entry_id: &EntryID, cx: &mut Context) {
+        // Use the panel version directly to avoid a mutability conflict
+        let slot = self.panel.find_slot_mut(entry_id, 0).unwrap();
+        slot.inflate_meta(&mut self.config, cx);
+    }
+
     fn find_item_irow(&self, entry_id: &EntryID, item_uid: ItemUID) -> Option<usize> {
         let slot = self.find_slot(entry_id)?;
         for tile in slot.tiles.values() {
@@ -2619,6 +2625,7 @@ impl eframe::App for ProfApp {
             items_selected.retain(|_, item| {
                 // Populate the item meta if it's not already there
                 if item.meta.is_none() {
+                    window.inflate_meta(&item.loc.entry_id, cx);
                     if let Some(meta) = window.find_item_meta(&item.loc.entry_id, item.loc.item_uid)
                     {
                         item.meta = Some(meta.clone());


### PR DESCRIPTION
This has two changes:

 * When scrolling to an item with an unknown row, do a second scroll once we discover what that row is so that the item stays in the center of the screen
 * Pop up a window with item details after the user clicks "Zoom to Item". The window will initially be empty but will populate once the metadata is available.