### PR TITLE
Restore solid scroll bar style from egui pre-0.24

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1905,6 +1905,12 @@ impl ProfApp {
         };
         cc.egui_ctx.set_visuals(theme);
 
+        // Set solid scroll bar (default from egui pre-0.24)
+        // The new default "thin" style isn't clickable with our canvas widget
+        cc.egui_ctx.style_mut(|style| {
+            style.spacing.scroll = egui::style::ScrollStyle::solid();
+        });
+
         result
     }
 


### PR DESCRIPTION
A new scrollbar style was added in egui 0.24 (see https://github.com/emilk/egui/pull/3539), but it's not clickable with our canvas. Probably we're missing with the hit detection, but it's easier to just shut it off.