### PR TITLE
Generate index.html for archive format.

### DIFF
--- a/src/archive_data.rs
+++ b/src/archive_data.rs
@@ -254,8 +254,9 @@ impl<T: DeferredDataSource> DataSourceArchiveWriter<T> {
             }
         });
 
-        std::fs::write(self.path.join("index.html"),
-                       "<html>
+        std::fs::write(
+            self.path.join("index.html"),
+            "<html>
 <script>
 window.onload = function() {
   var prof = location
@@ -265,7 +266,9 @@ window.onload = function() {
   window.location.replace(\"https://legion.stanford.edu/prof-viewer/?url=\"+prof.href);
 }
 </script>
-</html>")?;
+</html>
+",
+        )?;
 
         Ok(())
     }

--- a/src/archive_data.rs
+++ b/src/archive_data.rs
@@ -254,6 +254,19 @@ impl<T: DeferredDataSource> DataSourceArchiveWriter<T> {
             }
         });
 
+        std::fs::write(self.path.join("index.html"),
+                       "<html>
+<script>
+window.onload = function() {
+  var prof = location
+  if(location.protocol !== 'https:') {
+    prof = location.replace(`https:${location.href.substring(location.protocol.length)}`);
+  }
+  window.location.replace(\"https://legion.stanford.edu/prof-viewer/?url=\"+prof.href);
+}
+</script>
+</html>")?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Generate an index.html for the archive format so we can load on click on sapling instead of having to copy/paste a url. 