### PR TITLE
Ensure we always render each table row at least one line high

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2401,6 +2401,9 @@ impl ProfApp {
             return None;
         };
 
+        let font_id = TextStyle::Body.resolve(ui.style());
+        let row_height = ui.fonts(|f| f.row_height(&font_id));
+
         let mut result: Option<(ItemLocator, Interval)> = None;
         TableBuilder::new(ui)
             .striped(true)
@@ -2414,7 +2417,8 @@ impl ProfApp {
                     let width = body.widths()[1];
 
                     let ui = body.ui_mut();
-                    let height = Self::compute_field_height(field, width, cx.item_link_mode, ui);
+                    let height = Self::compute_field_height(field, width, cx.item_link_mode, ui)
+                        .max(row_height);
 
                     body.row(height, |mut row| {
                         row.col(|ui| {


### PR DESCRIPTION
Make sure that we don't collapse an empty row down below one line in height.

Note: I believe that the first column (the labels) will always be expanded to avoid wrapping, so therefore it isn't necessary to consider text wrapping in this case.