### PR TITLE
Remove `DataSourceMut`

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -221,52 +221,6 @@ pub trait DataSource {
         -> SlotMetaTile;
 }
 
-pub trait DataSourceMut {
-    fn fetch_description(&self) -> DataSourceDescription;
-    fn fetch_info(&mut self) -> DataSourceInfo;
-    fn fetch_summary_tile(
-        &mut self,
-        entry_id: &EntryID,
-        tile_id: TileID,
-        full: bool,
-    ) -> SummaryTile;
-    fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SlotTile;
-    fn fetch_slot_meta_tile(
-        &mut self,
-        entry_id: &EntryID,
-        tile_id: TileID,
-        full: bool,
-    ) -> SlotMetaTile;
-}
-
-impl<T: DataSource> DataSourceMut for T {
-    fn fetch_description(&self) -> DataSourceDescription {
-        DataSource::fetch_description(self)
-    }
-    fn fetch_info(&mut self) -> DataSourceInfo {
-        DataSource::fetch_info(self)
-    }
-    fn fetch_summary_tile(
-        &mut self,
-        entry_id: &EntryID,
-        tile_id: TileID,
-        full: bool,
-    ) -> SummaryTile {
-        DataSource::fetch_summary_tile(self, entry_id, tile_id, full)
-    }
-    fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SlotTile {
-        DataSource::fetch_slot_tile(self, entry_id, tile_id, full)
-    }
-    fn fetch_slot_meta_tile(
-        &mut self,
-        entry_id: &EntryID,
-        tile_id: TileID,
-        full: bool,
-    ) -> SlotMetaTile {
-        DataSource::fetch_slot_meta_tile(self, entry_id, tile_id, full)
-    }
-}
-
 impl EntryID {
     pub fn root() -> Self {
         Self(Vec::new())

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -1,5 +1,5 @@
 use crate::data::{
-    DataSourceDescription, DataSourceInfo, DataSourceMut, EntryID, SlotMetaTile, SlotTile,
+    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile,
     SummaryTile, TileID,
 };
 
@@ -15,7 +15,7 @@ pub trait DeferredDataSource {
     fn get_slot_meta_tiles(&mut self) -> Vec<SlotMetaTile>;
 }
 
-pub struct DeferredDataSourceWrapper<T: DataSourceMut> {
+pub struct DeferredDataSourceWrapper<T: DataSource> {
     data_source: T,
     infos: Vec<DataSourceInfo>,
     summary_tiles: Vec<SummaryTile>,
@@ -23,7 +23,7 @@ pub struct DeferredDataSourceWrapper<T: DataSourceMut> {
     slot_meta_tiles: Vec<SlotMetaTile>,
 }
 
-impl<T: DataSourceMut> DeferredDataSourceWrapper<T> {
+impl<T: DataSource> DeferredDataSourceWrapper<T> {
     pub fn new(data_source: T) -> Self {
         Self {
             data_source,
@@ -35,7 +35,7 @@ impl<T: DataSourceMut> DeferredDataSourceWrapper<T> {
     }
 }
 
-impl<T: DataSourceMut> DeferredDataSource for DeferredDataSourceWrapper<T> {
+impl<T: DataSource> DeferredDataSource for DeferredDataSourceWrapper<T> {
     fn fetch_description(&self) -> DataSourceDescription {
         self.data_source.fetch_description()
     }


### PR DESCRIPTION
In practice we always use plain `DataSource` anyway for compatibility with `ParallelDeferredDataSource`, so remove the unnecessary interface and move the test `DataSource` in main over to the plain interface.