### PR TITLE
Standalone mode for viewer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,12 @@ categories = ["development-tools::profiling"]
 license = "Apache-2.0"
 
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.77"
+
+# Required to ensure metadata is visible to dependents. See:
+# https://doc.rust-lang.org/cargo/reference/build-scripts.html
+# https://github.com/rust-lang/cargo/issues/7846
+links="legion_prof_viewer"
 
 [features]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    println!("cargo::metadata=SOURCE={}", manifest_dir);
+
+    // Don't rerun, we don't actually depend on anything
+    println!("cargo::rerun-if-changed=build.rs");
+
+    println!("cargo::warning=Saving path: {}", manifest_dir)
+}


### PR DESCRIPTION
This PR represents the first half of the work required to generate standalone archives with the profiler, where a user can load the archive directly on any webserver. This requires embedding the WASM blob produced by Trunk into the archive itself, which in turn requires embedding it in the code.

This version of the PR is intended to be used along with a `build.rs` script in the main Legion Prof implementation to actually run `trunk`. This PR only sets the variable so that it is accessible in the rest of the build.