### PR TITLE
Standalone mode for viewer (self build)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,12 @@ categories = ["development-tools::profiling"]
 license = "Apache-2.0"
 
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.77"
+
+# Required to ensure metadata is visible to dependents. See:
+# https://doc.rust-lang.org/cargo/reference/build-scripts.html
+# https://github.com/rust-lang/cargo/issues/7846
+links="legion_prof_viewer"
 
 [features]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+use std::process::Command;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dist_dir = Path::new(&out_dir).join("dist");
+
+    Command::new("trunk").args(["build", "--release", "--dist"]).arg(dist_dir).spawn().expect("Trunk failed");
+}


### PR DESCRIPTION
Similar to #64, except it runs the Trunk build directly.

This hits a deadlock because the Cargo lock on the build is already taken:

```
[legion_prof_viewer 0.3.0]     Blocking waiting for file lock on build directory
Building [=======================> ] 205/208: legion_prof_viewer(build)
```

Unless the deadlock can be fixed, this is a dead end.