### PR TITLE
Handle errors when fetching tiles

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::data::{
     DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, FieldID, FieldSchema, ItemLink,
     ItemMeta, ItemUID, SlotMetaTileData, SlotTileData, SummaryTileData, TileID, TileSet, UtilPoint,
 };
-use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource};
+use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource, TileResult};
 use crate::timestamp::{
     Interval, Timestamp, TimestampDisplay, TimestampParseError, TimestampUnits,
 };
@@ -55,7 +55,7 @@ use crate::timestamp::{
 struct Summary {
     entry_id: EntryID,
     color: Color32,
-    tiles: BTreeMap<TileID, Option<SummaryTileData>>,
+    tiles: BTreeMap<TileID, Option<TileResult<SummaryTileData>>>,
     last_view_interval: Option<Interval>,
 }
 
@@ -67,9 +67,17 @@ struct Slot {
     expanded: bool,
     max_rows: u64,
     tile_ids: Vec<TileID>,
-    tiles: BTreeMap<TileID, Option<SlotTileData>>,
-    tile_metas: BTreeMap<TileID, Option<SlotMetaTileData>>,
-    tile_metas_full: BTreeMap<TileID, Option<SlotMetaTileData>>,
+
+    // These maps have to track four different kinds of states:
+    //
+    //  1. Entry missing: user navigated away before response came back.
+    //  2. None: awaiting response.
+    //  3. Some(Err(_)): response failed or returned with an error.
+    //  4. Some(Ok(_)): successfully completed response.
+    tiles: BTreeMap<TileID, Option<TileResult<SlotTileData>>>,
+    tile_metas: BTreeMap<TileID, Option<TileResult<SlotMetaTileData>>>,
+    tile_metas_full: BTreeMap<TileID, Option<TileResult<SlotMetaTileData>>>,
+
     last_view_interval: Option<Interval>,
 }
 
@@ -501,6 +509,12 @@ impl Entry for Summary {
         let mut last_point: Option<Pos2> = None;
         let mut hover_util = None;
         for tile in self.tiles.values().flatten() {
+            let Ok(tile) = tile else {
+                // Paint the entire tile red to indicate the error.
+                ui.painter().rect(rect, 0.0, Color32::RED, Stroke::NONE);
+                return;
+            };
+
             for util in &tile.utilization {
                 let mut point = util_to_screen(util);
                 if let Some(mut last) = last_point {
@@ -633,7 +647,7 @@ impl Slot {
         tile_id: TileID,
         config: &mut Config,
         full: bool,
-    ) -> Option<&SlotMetaTileData> {
+    ) -> Option<&TileResult<SlotMetaTileData>> {
         let metas = if full {
             &mut self.tile_metas_full
         } else {
@@ -672,6 +686,12 @@ impl Slot {
             return hover_pos;
         }
         let tile = tile.as_ref().unwrap();
+
+        let Ok(tile) = tile else {
+            // Paint the entire tile red to indicate the error.
+            ui.painter().rect(rect, 0.0, Color32::RED, Stroke::NONE);
+            return hover_pos;
+        };
 
         if !cx.view_interval.overlaps(tile_id.0) {
             return hover_pos;
@@ -763,6 +783,14 @@ impl Slot {
             // Hack: clone here  to avoid mutability conflict.
             let entry_id = self.entry_id.clone();
             if let Some(tile_meta) = self.fetch_meta_tile(tile_id, config, false) {
+                let tile_meta = match tile_meta {
+                    Ok(t) => t,
+                    Err(e) => {
+                        ui.show_tooltip("task_tooltip", &item_rect, e);
+                        return hover_pos;
+                    }
+                };
+
                 let item_meta = &tile_meta.items[row][item_idx];
                 ui.show_tooltip_ui("task_tooltip", &item_rect, |ui| {
                     ui.label(&item_meta.title);
@@ -881,7 +909,7 @@ impl Entry for Slot {
         }
 
         for (tile_id, tile) in &self.tile_metas_full {
-            if let Some(tile) = tile {
+            if let Some(Ok(tile)) = tile {
                 if !config.search_state.start_tile(self, *tile_id) {
                     continue;
                 }
@@ -1505,7 +1533,7 @@ impl Window {
     fn find_item_irow(&self, entry_id: &EntryID, item_uid: ItemUID) -> Option<usize> {
         let slot = self.find_slot(entry_id)?;
         for tile in slot.tiles.values() {
-            let Some(tile) = tile else {
+            let Some(Ok(tile)) = tile else {
                 continue;
             };
             for (row, items) in tile.items.iter().enumerate() {
@@ -1523,7 +1551,7 @@ impl Window {
     fn find_item_meta(&self, entry_id: &EntryID, item_uid: ItemUID) -> Option<&ItemMeta> {
         let slot = self.find_slot(entry_id)?;
         for tile in slot.tile_metas.values() {
-            let Some(tile) = tile else {
+            let Some(Ok(tile)) = tile else {
                 continue;
             };
             for items in &tile.items {
@@ -2538,40 +2566,40 @@ impl eframe::App for ProfApp {
         }
 
         for window in windows.iter_mut() {
-            for (tile, _) in window.config.data_source.get_summary_tiles() {
-                if let Some(entry) = window.find_summary_mut(&tile.entry_id) {
+            for (tile, req) in window.config.data_source.get_summary_tiles() {
+                if let Some(entry) = window.find_summary_mut(&req.entry_id) {
                     // If the entry doesn't exist, we already zoomed away and
                     // are no longer interested in this tile.
                     entry
                         .tiles
-                        .entry(tile.tile_id)
-                        .and_modify(|t| *t = Some(tile.data));
+                        .entry(req.tile_id)
+                        .and_modify(|t| *t = Some(tile.map(|s| s.data)));
                 }
             }
 
-            for (tile, _) in window.config.data_source.get_slot_tiles() {
-                if let Some(entry) = window.find_slot_mut(&tile.entry_id) {
+            for (tile, req) in window.config.data_source.get_slot_tiles() {
+                if let Some(entry) = window.find_slot_mut(&req.entry_id) {
                     // If the entry doesn't exist, we already zoomed away and
                     // are no longer interested in this tile.
                     entry
                         .tiles
-                        .entry(tile.tile_id)
-                        .and_modify(|t| *t = Some(tile.data));
+                        .entry(req.tile_id)
+                        .and_modify(|t| *t = Some(tile.map(|s| s.data)));
                 }
             }
 
-            for (tile, full) in window.config.data_source.get_slot_meta_tiles() {
-                if let Some(entry) = window.find_slot_mut(&tile.entry_id) {
+            for (tile, req) in window.config.data_source.get_slot_meta_tiles() {
+                if let Some(entry) = window.find_slot_mut(&req.entry_id) {
                     // If the entry doesn't exist, we already zoomed away and
                     // are no longer interested in this tile.
-                    let metas = if full {
+                    let metas = if req.full {
                         &mut entry.tile_metas_full
                     } else {
                         &mut entry.tile_metas
                     };
                     metas
-                        .entry(tile.tile_id)
-                        .and_modify(|t| *t = Some(tile.data));
+                        .entry(req.tile_id)
+                        .and_modify(|t| *t = Some(tile.map(|s| s.data)));
                 }
             }
         }

--- a/src/archive_data.rs
+++ b/src/archive_data.rs
@@ -122,6 +122,7 @@ impl<T: DeferredDataSource> DataSourceArchiveWriter<T> {
 
     fn write_summary_tiles(&mut self, scope: &rayon::Scope<'_>) {
         for (tile, _) in self.data_source.get_summary_tiles() {
+            let tile = tile.expect("writing summary tile failed");
             let mut path = self.path.join("summary_tile");
             let req = TileRequestRef {
                 entry_id: &tile.entry_id,
@@ -134,6 +135,7 @@ impl<T: DeferredDataSource> DataSourceArchiveWriter<T> {
 
     fn write_slot_tiles(&mut self, scope: &rayon::Scope<'_>) {
         for (tile, _) in self.data_source.get_slot_tiles() {
+            let tile = tile.expect("writing slot tile failed");
             let mut path = self.path.join("slot_tile");
             let req = TileRequestRef {
                 entry_id: &tile.entry_id,
@@ -146,6 +148,7 @@ impl<T: DeferredDataSource> DataSourceArchiveWriter<T> {
 
     fn write_slot_meta_tiles(&mut self, scope: &rayon::Scope<'_>) {
         for (tile, _) in self.data_source.get_slot_meta_tiles() {
+            let tile = tile.expect("writing slot meta tile failed");
             let mut path = self.path.join("slot_meta_tile");
             let req = TileRequestRef {
                 entry_id: &tile.entry_id,

--- a/src/merge_data.rs
+++ b/src/merge_data.rs
@@ -4,7 +4,9 @@ use crate::data::{
     DataSourceDescription, DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, ItemLink,
     ItemUID, SlotMetaTile, SlotTile, SummaryTile, TileID,
 };
-use crate::deferred_data::DeferredDataSource;
+use crate::deferred_data::{
+    DeferredDataSource, SlotMetaTileResponse, SlotTileResponse, SummaryTileResponse,
+};
 use crate::timestamp::Interval;
 
 pub struct MergeDeferredDataSource {
@@ -232,7 +234,7 @@ impl DeferredDataSource for MergeDeferredDataSource {
         self.data_sources[idx].fetch_summary_tile(&src_entry, tile_id, full);
     }
 
-    fn get_summary_tiles(&mut self) -> Vec<(SummaryTile, bool)> {
+    fn get_summary_tiles(&mut self) -> Vec<SummaryTileResponse> {
         let mut tiles = Vec::new();
         for (idx, data_source) in self.data_sources.iter_mut().enumerate() {
             tiles.extend(
@@ -246,7 +248,7 @@ impl DeferredDataSource for MergeDeferredDataSource {
         // Hack: doing this in two stages to avoid mutability conflict
         tiles
             .into_iter()
-            .map(|(idx, (tile, full))| (self.map_src_to_dst_summary(idx, tile), full))
+            .map(|(idx, (tile, req))| (tile.map(|t| self.map_src_to_dst_summary(idx, t)), req))
             .collect()
     }
 
@@ -256,7 +258,7 @@ impl DeferredDataSource for MergeDeferredDataSource {
         self.data_sources[idx].fetch_slot_tile(&src_entry, tile_id, full);
     }
 
-    fn get_slot_tiles(&mut self) -> Vec<(SlotTile, bool)> {
+    fn get_slot_tiles(&mut self) -> Vec<SlotTileResponse> {
         let mut tiles = Vec::new();
         for (idx, data_source) in self.data_sources.iter_mut().enumerate() {
             tiles.extend(
@@ -270,7 +272,7 @@ impl DeferredDataSource for MergeDeferredDataSource {
         // Hack: doing this in two stages to avoid mutability conflict
         tiles
             .into_iter()
-            .map(|(idx, (tile, full))| (self.map_src_to_dst_slot(idx, tile), full))
+            .map(|(idx, (tile, req))| (tile.map(|t| self.map_src_to_dst_slot(idx, t)), req))
             .collect()
     }
 
@@ -280,7 +282,7 @@ impl DeferredDataSource for MergeDeferredDataSource {
         self.data_sources[idx].fetch_slot_meta_tile(&src_entry, tile_id, full);
     }
 
-    fn get_slot_meta_tiles(&mut self) -> Vec<(SlotMetaTile, bool)> {
+    fn get_slot_meta_tiles(&mut self) -> Vec<SlotMetaTileResponse> {
         let mut tiles = Vec::new();
         for (idx, data_source) in self.data_sources.iter_mut().enumerate() {
             tiles.extend(
@@ -294,7 +296,7 @@ impl DeferredDataSource for MergeDeferredDataSource {
         // Hack: doing this in two stages to avoid mutability conflict
         tiles
             .into_iter()
-            .map(|(idx, (tile, full))| (self.map_src_to_dst_slot_meta(idx, tile), full))
+            .map(|(idx, (tile, req))| (tile.map(|t| self.map_src_to_dst_slot_meta(idx, t)), req))
             .collect()
     }
 }

--- a/src/nvtxw.rs
+++ b/src/nvtxw.rs
@@ -193,11 +193,13 @@ impl<T: DeferredDataSource> NVTXW<T> {
             let slot_meta_tiles = data_source.get_slot_meta_tiles();
 
             for (tile, _) in slot_tiles {
+                let tile = tile.expect("writing slot tile failed");
                 let e = tile.entry_id.clone();
                 unmatched_tiles.entry(e).or_insert((None, None)).0 = Some(tile);
             }
 
             for (meta_tile, _) in slot_meta_tiles {
+                let meta_tile = meta_tile.expect("writing slot meta tile failed");
                 let e = meta_tile.entry_id.clone();
                 unmatched_tiles.entry(e).or_insert((None, None)).1 = Some(meta_tile);
             }

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -1,17 +1,16 @@
 use std::sync::{Arc, Mutex};
 
-use crate::data::{
-    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile,
-    SummaryTile, TileID,
+use crate::data::{DataSource, DataSourceDescription, DataSourceInfo, EntryID, TileID};
+use crate::deferred_data::{
+    DeferredDataSource, SlotMetaTileResponse, SlotTileResponse, SummaryTileResponse, TileRequest,
 };
-use crate::deferred_data::DeferredDataSource;
 
 pub struct ParallelDeferredDataSource<T: DataSource + Send + Sync + 'static> {
     data_source: Arc<T>,
     infos: Arc<Mutex<Vec<DataSourceInfo>>>,
-    summary_tiles: Arc<Mutex<Vec<(SummaryTile, bool)>>>,
-    slot_tiles: Arc<Mutex<Vec<(SlotTile, bool)>>>,
-    slot_meta_tiles: Arc<Mutex<Vec<(SlotMetaTile, bool)>>>,
+    summary_tiles: Arc<Mutex<Vec<SummaryTileResponse>>>,
+    slot_tiles: Arc<Mutex<Vec<SlotTileResponse>>>,
+    slot_meta_tiles: Arc<Mutex<Vec<SlotMetaTileResponse>>>,
 }
 
 impl<T: DataSource + Send + Sync + 'static> ParallelDeferredDataSource<T> {
@@ -50,11 +49,16 @@ impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDefer
         let summary_tiles = self.summary_tiles.clone();
         rayon::spawn(move || {
             let result = data_source.fetch_summary_tile(&entry_id, tile_id, full);
-            summary_tiles.lock().unwrap().push((result, full));
+            let req = TileRequest {
+                entry_id: entry_id.clone(),
+                tile_id,
+                full,
+            };
+            summary_tiles.lock().unwrap().push((Ok(result), req));
         });
     }
 
-    fn get_summary_tiles(&mut self) -> Vec<(SummaryTile, bool)> {
+    fn get_summary_tiles(&mut self) -> Vec<SummaryTileResponse> {
         std::mem::take(&mut self.summary_tiles.lock().unwrap())
     }
 
@@ -64,11 +68,16 @@ impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDefer
         let slot_tiles = self.slot_tiles.clone();
         rayon::spawn(move || {
             let result = data_source.fetch_slot_tile(&entry_id, tile_id, full);
-            slot_tiles.lock().unwrap().push((result, full));
+            let req = TileRequest {
+                entry_id: entry_id.clone(),
+                tile_id,
+                full,
+            };
+            slot_tiles.lock().unwrap().push((Ok(result), req));
         });
     }
 
-    fn get_slot_tiles(&mut self) -> Vec<(SlotTile, bool)> {
+    fn get_slot_tiles(&mut self) -> Vec<SlotTileResponse> {
         std::mem::take(&mut self.slot_tiles.lock().unwrap())
     }
 
@@ -78,11 +87,16 @@ impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDefer
         let slot_meta_tiles = self.slot_meta_tiles.clone();
         rayon::spawn(move || {
             let result = data_source.fetch_slot_meta_tile(&entry_id, tile_id, full);
-            slot_meta_tiles.lock().unwrap().push((result, full));
+            let req = TileRequest {
+                entry_id: entry_id.clone(),
+                tile_id,
+                full,
+            };
+            slot_meta_tiles.lock().unwrap().push((Ok(result), req));
         });
     }
 
-    fn get_slot_meta_tiles(&mut self) -> Vec<(SlotMetaTile, bool)> {
+    fn get_slot_meta_tiles(&mut self) -> Vec<SlotMetaTileResponse> {
         std::mem::take(&mut self.slot_meta_tiles.lock().unwrap())
     }
 }


### PR DESCRIPTION
Addresses part of #78.

The data pathway for tiles now tracks errors all the way through to the app, where they can be displayed if something went wrong.