### PR TITLE
Add an LRU cache on data source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1557,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1901,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,7 +2109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2230,6 +2253,7 @@ dependencies = [
  "getrandom 0.2.12",
  "itertools 0.14.0",
  "log",
+ "lru",
  "nvtxw",
  "percentage",
  "rand",
@@ -2326,6 +2350,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+dependencies = [
+ "hashbrown 0.15.3",
+]
 
 [[package]]
 name = "malloc_buf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rand = { version = "0.8" }
 getrandom = { version = "0.2", features = ["js"] }
 
 itertools = "0.14.0"
+lru = "0.14"
 percentage = "0.1.0"
 regex = "1.11.0"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
@@ -17,7 +18,9 @@ use crate::data::{
     DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, FieldID, FieldSchema, ItemLink,
     ItemMeta, ItemUID, SlotMetaTileData, SlotTileData, SummaryTileData, TileID, TileSet, UtilPoint,
 };
-use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource, TileResult};
+use crate::deferred_data::{
+    CountingDeferredDataSource, DeferredDataSource, LruDeferredDataSource, TileResult,
+};
 use crate::timestamp::{
     Interval, Timestamp, TimestampDisplay, TimestampParseError, TimestampUnits,
 };
@@ -165,7 +168,7 @@ struct Config {
     tile_set: TileSet,
     warning_message: Option<String>,
 
-    data_source: CountingDeferredDataSource<Box<dyn DeferredDataSource>>,
+    data_source: CountingDeferredDataSource<LruDeferredDataSource<Box<dyn DeferredDataSource>>>,
 
     search_state: SearchState,
 
@@ -1438,7 +1441,10 @@ impl Config {
             interval,
             tile_set,
             warning_message,
-            data_source: CountingDeferredDataSource::new(data_source),
+            data_source: CountingDeferredDataSource::new(LruDeferredDataSource::new(
+                data_source,
+                NonZeroUsize::new(1024).unwrap(),
+            )),
             search_state,
             items_selected: BTreeMap::new(),
             scroll_to_item: None,

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,7 +10,7 @@ use crate::timestamp::{Interval, Timestamp};
 // We encode EntryID as i64 because it allows us to pack Summary into the
 // value -1. Users shouldn't need to know about this and interact through the
 // methods below, or via EntryIndex.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct EntryID(Vec<i64>);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -163,7 +163,7 @@ pub struct ItemMeta {
     pub fields: Vec<(FieldID, Field, Option<Color32>)>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct TileID(pub Interval);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -1,8 +1,13 @@
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+
 use crate::data::{
     DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile,
     SummaryTile, TileID,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TileRequest {
     pub entry_id: EntryID,
     pub tile_id: TileID,
@@ -186,6 +191,101 @@ impl<T: DeferredDataSource> DeferredDataSource for CountingDeferredDataSource<T>
     fn get_slot_meta_tiles(&mut self) -> Vec<SlotMetaTileResponse> {
         let result = self.data_source.get_slot_meta_tiles();
         self.finish_request(result)
+    }
+}
+
+pub struct LruDeferredDataSource<T: DeferredDataSource> {
+    data_source: T,
+    summary_cache: LruCache<TileRequest, SummaryTileResponse>,
+    slot_cache: LruCache<TileRequest, SlotTileResponse>,
+    slot_meta_cache: LruCache<TileRequest, SlotMetaTileResponse>,
+    summary_tiles: Vec<SummaryTileResponse>,
+    slot_tiles: Vec<SlotTileResponse>,
+    slot_meta_tiles: Vec<SlotMetaTileResponse>,
+}
+
+impl<T: DeferredDataSource> LruDeferredDataSource<T> {
+    pub fn new(data_source: T, capacity: NonZeroUsize) -> Self {
+        Self {
+            data_source,
+            summary_cache: LruCache::new(capacity),
+            slot_cache: LruCache::new(capacity),
+            slot_meta_cache: LruCache::new(capacity),
+            summary_tiles: Vec::new(),
+            slot_tiles: Vec::new(),
+            slot_meta_tiles: Vec::new(),
+        }
+    }
+}
+
+impl<T: DeferredDataSource> DeferredDataSource for LruDeferredDataSource<T> {
+    fn fetch_description(&self) -> DataSourceDescription {
+        self.data_source.fetch_description()
+    }
+
+    fn fetch_info(&mut self) {
+        self.data_source.fetch_info()
+    }
+
+    fn get_infos(&mut self) -> Vec<DataSourceInfo> {
+        self.data_source.get_infos()
+    }
+
+    fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) {
+        let req = TileRequest {
+            entry_id: entry_id.clone(),
+            tile_id,
+            full,
+        };
+        if let Some(tile) = self.summary_cache.get(&req) {
+            self.summary_tiles.push(tile.clone());
+        } else {
+            self.data_source.fetch_summary_tile(entry_id, tile_id, full);
+        }
+    }
+
+    fn get_summary_tiles(&mut self) -> Vec<SummaryTileResponse> {
+        self.summary_tiles
+            .extend(self.data_source.get_summary_tiles());
+        std::mem::take(&mut self.summary_tiles)
+    }
+
+    fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) {
+        let req = TileRequest {
+            entry_id: entry_id.clone(),
+            tile_id,
+            full,
+        };
+        if let Some(tile) = self.slot_cache.get(&req) {
+            self.slot_tiles.push(tile.clone());
+        } else {
+            self.data_source.fetch_slot_tile(entry_id, tile_id, full);
+        }
+    }
+
+    fn get_slot_tiles(&mut self) -> Vec<SlotTileResponse> {
+        self.slot_tiles.extend(self.data_source.get_slot_tiles());
+        std::mem::take(&mut self.slot_tiles)
+    }
+
+    fn fetch_slot_meta_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) {
+        let req = TileRequest {
+            entry_id: entry_id.clone(),
+            tile_id,
+            full,
+        };
+        if let Some(tile) = self.slot_meta_cache.get(&req) {
+            self.slot_meta_tiles.push(tile.clone());
+        } else {
+            self.data_source
+                .fetch_slot_meta_tile(entry_id, tile_id, full);
+        }
+    }
+
+    fn get_slot_meta_tiles(&mut self) -> Vec<SlotMetaTileResponse> {
+        self.slot_meta_tiles
+            .extend(self.data_source.get_slot_meta_tiles());
+        std::mem::take(&mut self.slot_meta_tiles)
     }
 }
 

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -245,8 +245,11 @@ impl<T: DeferredDataSource> DeferredDataSource for LruDeferredDataSource<T> {
     }
 
     fn get_summary_tiles(&mut self) -> Vec<SummaryTileResponse> {
-        self.summary_tiles
-            .extend(self.data_source.get_summary_tiles());
+        let result = self.data_source.get_summary_tiles();
+        for tile in &result {
+            self.summary_cache.put(tile.1.clone(), tile.clone());
+        }
+        self.summary_tiles.extend(result);
         std::mem::take(&mut self.summary_tiles)
     }
 
@@ -264,7 +267,11 @@ impl<T: DeferredDataSource> DeferredDataSource for LruDeferredDataSource<T> {
     }
 
     fn get_slot_tiles(&mut self) -> Vec<SlotTileResponse> {
-        self.slot_tiles.extend(self.data_source.get_slot_tiles());
+        let result = self.data_source.get_slot_tiles();
+        for tile in &result {
+            self.slot_cache.put(tile.1.clone(), tile.clone());
+        }
+        self.slot_tiles.extend(result);
         std::mem::take(&mut self.slot_tiles)
     }
 
@@ -283,8 +290,11 @@ impl<T: DeferredDataSource> DeferredDataSource for LruDeferredDataSource<T> {
     }
 
     fn get_slot_meta_tiles(&mut self) -> Vec<SlotMetaTileResponse> {
-        self.slot_meta_tiles
-            .extend(self.data_source.get_slot_meta_tiles());
+        let result = self.data_source.get_slot_meta_tiles();
+        for tile in &result {
+            self.slot_meta_cache.put(tile.1.clone(), tile.clone());
+        }
+        self.slot_meta_tiles.extend(result);
         std::mem::take(&mut self.slot_meta_tiles)
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2,7 +2,9 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Deserialize, Serialize,
+)]
 pub struct Timestamp(pub i64 /* ns */);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -52,7 +54,9 @@ impl fmt::Display for Timestamp {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Deserialize, Serialize,
+)]
 pub struct Interval {
     pub start: Timestamp,
     pub stop: Timestamp, // exclusive


### PR DESCRIPTION
Not sure how to tune it, but right now it is configured to maintain up to 1024 tiles each for summary, slot and slot meta.