### PR TITLE
Always add trailing slash to URL if not provided by user

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -22,6 +22,7 @@ use crate::deferred_data::{
 };
 use crate::http::fetch::{DataSourceResponse, fetch};
 use crate::http::schema::TileRequestRef;
+use crate::http::url::ensure_directory;
 
 pub struct HTTPClientDataSource {
     pub baseurl: Url,
@@ -35,7 +36,7 @@ pub struct HTTPClientDataSource {
 impl HTTPClientDataSource {
     pub fn new(baseurl: Url) -> Self {
         Self {
-            baseurl,
+            baseurl: ensure_directory(&baseurl),
             client: ClientBuilder::new().build().unwrap(),
             infos: Arc::new(Mutex::new(Vec::new())),
             summary_tiles: Arc::new(Mutex::new(Vec::new())),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -12,3 +12,5 @@ pub mod fetch;
 pub mod fetch_native;
 #[cfg(all(feature = "client", target_arch = "wasm32"))]
 pub mod fetch_web;
+#[cfg(feature = "client")]
+pub mod url;

--- a/src/http/url.rs
+++ b/src/http/url.rs
@@ -1,0 +1,79 @@
+use url::Url;
+
+pub fn ensure_directory(url: &Url) -> Url {
+    let mut result = url.clone();
+
+    if let Ok(mut segments) = result.path_segments_mut() {
+        segments.pop_if_empty().push("");
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_trailing_slash() {
+        let url1 = Url::parse("https://example.net/a/b/c/").unwrap();
+        let url2 = Url::parse("https://example.net/a/b/c/").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_path_no_trailing_slash() {
+        let url1 = Url::parse("https://example.net/a/b/c").unwrap();
+        let url2 = Url::parse("https://example.net/a/b/c/").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_root_trailing_slash() {
+        let url1 = Url::parse("https://example.net/").unwrap();
+        let url2 = Url::parse("https://example.net/").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_root_no_trailing_slash() {
+        let url1 = Url::parse("https://example.net").unwrap();
+        let url2 = Url::parse("https://example.net/").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_query_trailing_slash() {
+        let url1 = Url::parse("https://example.net/a/b/c/?query=asdf").unwrap();
+        let url2 = Url::parse("https://example.net/a/b/c/?query=asdf").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_query_no_trailing_slash() {
+        let url1 = Url::parse("https://example.net/a/b/c?query=asdf").unwrap();
+        let url2 = Url::parse("https://example.net/a/b/c/?query=asdf").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_fragment_trailing_slash() {
+        let url1 = Url::parse("https://example.net/a/b/c/#fragment").unwrap();
+        let url2 = Url::parse("https://example.net/a/b/c/#fragment").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_fragment_no_trailing_slash() {
+        let url1 = Url::parse("https://example.net/a/b/c#fragment").unwrap();
+        let url2 = Url::parse("https://example.net/a/b/c/#fragment").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+
+    #[test]
+    fn test_mailto() {
+        let url1 = Url::parse("mailto:user@example.com").unwrap();
+        let url2 = Url::parse("mailto:user@example.com").unwrap();
+        assert_eq!(ensure_directory(&url1), url2);
+    }
+}


### PR DESCRIPTION
Partially addresses #78.

This addresses a common failure mode where the user forgets to type the trailing `/`, resulting in the viewer failing to start. Because we know that profiles are *always* directories we can add this `/` unconditionally without fear of causing problems.