### PR TITLE
Improve tile manager algorithm

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,0 +1,4 @@
+mod core;
+mod tile_manager;
+
+pub use core::start;

--- a/src/app/tile_manager.rs
+++ b/src/app/tile_manager.rs
@@ -1,0 +1,164 @@
+use crate::data::{TileID, TileSet};
+use crate::timestamp::Interval;
+
+pub struct TileManager {
+    tile_set: TileSet,
+    interval: Interval,
+    last_request_interval: (Option<Interval>, Option<Interval>), // full: false, true
+    tile_cache: (Vec<TileID>, Vec<TileID>),                      // full: false, true
+}
+
+fn select<T>(cond: bool, true_value: T, false_value: T) -> T {
+    if cond { true_value } else { false_value }
+}
+
+fn fill_cache<T: Clone, I: IntoIterator<Item = T>>(cache: &mut Vec<T>, values: I) -> Vec<T> {
+    cache.clear();
+    cache.extend(values);
+    cache.clone()
+}
+
+impl TileManager {
+    pub fn new(tile_set: TileSet, interval: Interval) -> Self {
+        Self {
+            tile_set,
+            interval,
+            last_request_interval: (None, None),
+            tile_cache: (Vec::new(), Vec::new()),
+        }
+    }
+
+    pub fn request_tiles(&mut self, view_interval: Interval, full: bool) -> Vec<TileID> {
+        let last_request_interval = select(
+            full,
+            &mut self.last_request_interval.1,
+            &mut self.last_request_interval.0,
+        );
+        let tile_cache = select(full, &mut self.tile_cache.1, &mut self.tile_cache.0);
+
+        let request_interval = view_interval.intersection(self.interval);
+        if *last_request_interval == Some(request_interval) {
+            return tile_cache.clone();
+        }
+
+        let request_duration = request_interval.duration_ns();
+        if request_duration <= 0 {
+            return Vec::new();
+        }
+
+        if self.tile_set.tiles.is_empty() {
+            // For dynamic profiles, just return the request as one tile.
+            *last_request_interval = Some(request_interval);
+            return fill_cache(tile_cache, [TileID(request_interval)]);
+        }
+
+        // We're in a static profile. Choose an appropriate level to load.
+        let chosen_level = if full {
+            // Full request must always fetch highest level of detail.
+            self.tile_set.tiles.last().unwrap()
+        } else {
+            // Otherwise estimate the best zoom level, where "best" minimizes the
+            // ratio of the tile size to request size.
+            let request_duration = request_interval.duration_ns();
+            let ratio = |level: &Vec<TileID>| {
+                let d = level.first().unwrap().0.duration_ns();
+                if d < request_duration {
+                    request_duration as f64 / d as f64
+                } else {
+                    d as f64 / request_duration as f64
+                }
+            };
+            self.tile_set
+                .tiles
+                .iter()
+                .min_by(|level1, level2| ratio(level1).partial_cmp(&ratio(level2)).unwrap())
+                .unwrap()
+        };
+
+        // Now filter to just tiles overlapping the requested interval.
+        *last_request_interval = Some(request_interval);
+        fill_cache(
+            tile_cache,
+            chosen_level
+                .iter()
+                .filter(|tile| request_interval.overlaps(tile.0))
+                .copied(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::timestamp::Timestamp;
+
+    #[test]
+    fn test_dynamic_empty() {
+        let int = Interval::new(Timestamp(0), Timestamp(10));
+        let req = Interval::new(Timestamp(5), Timestamp(5));
+        let mut tm = TileManager::new(TileSet::default(), int);
+        assert!(tm.request_tiles(req, false).is_empty());
+        assert!(tm.request_tiles(req, true).is_empty());
+    }
+
+    #[test]
+    fn test_static_empty() {
+        let int = Interval::new(Timestamp(0), Timestamp(100));
+        let req = Interval::new(Timestamp(25), Timestamp(25));
+        let ts = TileSet {
+            tiles: vec![
+                vec![TileID(int)],
+                vec![
+                    TileID(Interval::new(Timestamp(0), Timestamp(50))),
+                    TileID(Interval::new(Timestamp(50), Timestamp(100))),
+                ],
+            ],
+        };
+        let mut tm = TileManager::new(ts, int);
+        assert!(tm.request_tiles(req, false).is_empty());
+        assert!(tm.request_tiles(req, true).is_empty());
+    }
+
+    #[test]
+    fn test_dynamic_request() {
+        let int = Interval::new(Timestamp(0), Timestamp(10));
+        let req = Interval::new(Timestamp(0), Timestamp(10));
+        let mut tm = TileManager::new(TileSet::default(), int);
+        // Answer should be stable on repeat queries.
+        assert_eq!(tm.request_tiles(req, false), vec![TileID(req)]);
+        assert_eq!(tm.request_tiles(req, false), vec![TileID(req)]);
+        assert_eq!(tm.request_tiles(req, true), vec![TileID(req)]);
+        assert_eq!(tm.request_tiles(req, true), vec![TileID(req)]);
+    }
+
+    #[test]
+    fn test_static_request() {
+        let int = Interval::new(Timestamp(0), Timestamp(100));
+        let req = Interval::new(Timestamp(10), Timestamp(90));
+        let ts = TileSet {
+            tiles: vec![
+                vec![TileID(int)],
+                vec![
+                    TileID(Interval::new(Timestamp(0), Timestamp(50))),
+                    TileID(Interval::new(Timestamp(50), Timestamp(100))),
+                ],
+            ],
+        };
+        let mut tm = TileManager::new(ts, int);
+        let part = vec![TileID(Interval::new(Timestamp(0), Timestamp(100)))];
+        let full = vec![
+            TileID(Interval::new(Timestamp(0), Timestamp(50))),
+            TileID(Interval::new(Timestamp(50), Timestamp(100))),
+        ];
+        // Answer should be stable on repeat queries.
+        assert_eq!(&tm.request_tiles(req, false), &part);
+        assert_eq!(&tm.request_tiles(req, false), &part);
+        assert_eq!(&tm.request_tiles(req, true), &full);
+        assert_eq!(&tm.request_tiles(req, true), &full);
+        assert_eq!(&tm.request_tiles(req, false), &part);
+        assert_eq!(&tm.request_tiles(req, false), &part);
+        assert_eq!(&tm.request_tiles(req, true), &full);
+        assert_eq!(&tm.request_tiles(req, true), &full);
+    }
+}

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -100,7 +100,10 @@ impl Interval {
         self.stop.0 - self.start.0
     }
     pub fn contains(self, point: Timestamp) -> bool {
-        point >= self.start && point < self.stop
+        self.start <= point && point < self.stop
+    }
+    pub fn contains_interval(self, other: Interval) -> bool {
+        self.start <= other.start && other.stop <= self.stop
     }
     pub fn overlaps(self, other: Interval) -> bool {
         !(other.stop <= self.start || other.start >= self.stop)
@@ -458,6 +461,21 @@ mod tests {
             assert!(i0.contains(Timestamp(3)));
             assert!(!i0.contains(Timestamp(4))); // Not included!
             assert!(!i0.contains(Timestamp(5)));
+        }
+
+        #[test]
+        fn test_contains_interval() {
+            // Intervals are exclusive: they do NOT contain stop
+            let i0 = Interval::new(Timestamp(2), Timestamp(4));
+            assert!(!i0.contains_interval(Interval::new(Timestamp(1), Timestamp(4))));
+            assert!(i0.contains_interval(Interval::new(Timestamp(2), Timestamp(3))));
+            assert!(i0.contains_interval(Interval::new(Timestamp(3), Timestamp(4))));
+            assert!(i0.contains_interval(Interval::new(Timestamp(4), Timestamp(4))));
+            assert!(!i0.contains_interval(Interval::new(Timestamp(2), Timestamp(5))));
+            assert!(!i0.contains_interval(Interval::new(Timestamp(3), Timestamp(5))));
+            assert!(!i0.contains_interval(Interval::new(Timestamp(4), Timestamp(5))));
+            // Empty intervals are not contained unless they also fall inside
+            assert!(!i0.contains_interval(Interval::new(Timestamp(5), Timestamp(5))));
         }
 
         #[test]


### PR DESCRIPTION
This PR substantially refactors and improves the tile management in the viewer. Notable changes:

 * The entire tile selection infrastructure has been moved into its own struct `TileManager`, with unit tests
 * Cache invalidation is centralized and the new algorithm maintains tiles that are shared in common between old and new tile sets. This eliminates flickering when the tile sets can be partially or fully reused
 * Fixed a bug in the cache tracking that prevented cache entries from being reused
 * The algorithm for choosing tile sets for dynamic profiles has been entirely rewritten:
   * When making a new request, the request interval is used directly. There is no point in over-fetching, as the tiles are generated dynamically.
   * On subsequent requests, the previous tile set is reused if: (a) the magnification factor has changed by <= 2.0, and (b) there is at least some overlap with the existing tile set. The tile set is kept and augmented as needed if the new request extends past the old (e.g., zooming out, panning).