### PR TITLE
Load multiple data sources provided in arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,6 @@ fn main() {
     let href: String = loc.href().expect("unable to get window URL");
     let browser_url = Url::parse(&href).expect("unable to parse location URL");
 
-    const DEFAULT_URL: &str = "http://127.0.0.1:8080";
-
     let ds: Vec<_> = browser_url
         .query_pairs()
         .filter(|(key, _)| key.starts_with("url"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,23 @@
 #![warn(clippy::all, rust_2018_idioms)]
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use legion_prof_viewer::deferred_data::DeferredDataSource;
 use legion_prof_viewer::http::client::HTTPClientDataSource;
 
 use url::Url;
 
-const DEFAULT_URL: &str = "http://127.0.0.1:8080";
+fn http_ds(url: Url) -> Box<dyn DeferredDataSource> {
+    Box::new(HTTPClientDataSource::new(url))
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let url = Url::parse(std::env::args().nth(1).as_deref().unwrap_or(DEFAULT_URL))
-        .expect("unable to parse URL");
+    let ds: Vec<_> = std::env::args()
+        .skip(1)
+        .map(|arg| http_ds(Url::parse(&arg).expect("unable to parse URL")))
+        .collect();
 
-    legion_prof_viewer::app::start(vec![Box::new(HTTPClientDataSource::new(url))]);
+    legion_prof_viewer::app::start(ds);
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -21,15 +26,13 @@ fn main() {
     let href: String = loc.href().expect("unable to get window URL");
     let browser_url = Url::parse(&href).expect("unable to parse location URL");
 
-    let url = Url::parse(
-        browser_url
-            .query_pairs()
-            .find(|(key, _)| key == "url")
-            .map(|(_, value)| value)
-            .as_deref()
-            .unwrap_or(DEFAULT_URL),
-    )
-    .expect("unable to parse query URL");
+    const DEFAULT_URL: &str = "http://127.0.0.1:8080";
 
-    legion_prof_viewer::app::start(vec![Box::new(HTTPClientDataSource::new(url))]);
+    let ds: Vec<_> = browser_url
+        .query_pairs()
+        .filter(|(key, _)| key.starts_with("url"))
+        .map(|(_, value)| http_ds(Url::parse(value).expect("unable to parse query URL")))
+        .collect();
+
+    legion_prof_viewer::app::start(ds);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
     let ds: Vec<_> = browser_url
         .query_pairs()
         .filter(|(key, _)| key.starts_with("url"))
-        .map(|(_, value)| http_ds(Url::parse(value).expect("unable to parse query URL")))
+        .map(|(_, value)| http_ds(Url::parse(&value).expect("unable to parse query URL")))
         .collect();
 
     legion_prof_viewer::app::start(ds);


### PR DESCRIPTION
Updated behavior:

 * Native: read all command line arguments (instead of just one) as URLs to load
 * Web: read all query parameters that start with `url` (`url1`, `url2`, etc.) as URLs to load