### PR TITLE
Upgrade to egui 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,9 +1230,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57539aabcdbb733b6806ef421b66dec158dc1582107ad6d51913db3600303354"
+checksum = "03cfe80b1890e1a8cdbffc6044d6872e814aaf6011835a2a5e2db0e5c5c4ef4e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1231,13 +1240,14 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c00143a1d564cf27570234c9a199cbe75dc3d43a135510fb2b93406a87ee8e"
+checksum = "c456c1bb6d13bf68b780257484703d750c70a23ff891ba35f4d6e23a4dbdf26f"
 dependencies = [
  "bytemuck",
  "cocoa",
  "directories-next",
+ "document-features",
  "egui",
  "egui-winit",
  "egui_glow",
@@ -1251,6 +1261,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "ron",
  "serde",
  "static_assertions",
@@ -1258,15 +1269,16 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "web-time",
  "winapi",
  "winit",
 ]
 
 [[package]]
 name = "egui"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf640ed7f3bf3d14ebf00d73bacc09c886443ee84ca6494bde37953012c9e3"
+checksum = "180f595432a5b615fc6b74afef3955249b86cfea72607b40740a4cd60d5297d0"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1279,15 +1291,15 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d95d9762056c541bd2724de02910d8bccf3af8e37689dc114b21730e64f80a0"
+checksum = "aa4d44f8d89f70d4480545eb2346b76ea88c3022e9f4706cebc799dbe8b004a2"
 dependencies = [
  "accesskit_winit",
  "arboard",
  "egui",
  "log",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "serde",
  "smithay-clipboard",
  "web-time",
@@ -1297,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753c36d3e2f7a32425af5290af2e52efb3471ea3a263b87f003b5433351b0fd7"
+checksum = "3f4a6962241a76da5be5e64e41b851ee1c95fda11f76635522a3c82b119b5475"
 dependencies = [
  "egui",
  "enum-map",
@@ -1310,15 +1322,15 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb2ef815e80d117339c7d6b813f7678d23522d699ccd3243e267ef06166009b9"
+checksum = "a08e3be8728b4c59493dbfec041c657e6725bdeafdbd49aef3f1dbb9e551fa01"
 dependencies = [
  "bytemuck",
  "egui",
  "glow",
  "log",
- "memoffset 0.7.1",
+ "memoffset 0.9.0",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1331,9 +1343,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee58355767587db7ba3738930d93cad3052cd834c2b48b9ef6ef26fe4823b7e"
+checksum = "6916301ecf80448f786cdf3eb51d9dbdd831538732229d49119e2d4312eaaf09"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1416,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e638cb066bff0903bbb6143116cfd134a42279c7d68f19c0352a94f15a402de7"
+checksum = "77b9fdf617dd7f58b0c8e6e9e4a1281f730cde0831d40547da446b2bb76a47af"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2317,6 +2329,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "local-channel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ server = ["dep:actix-cors", "dep:actix-web"]
 nvtxw = ["dep:nvtxw"]
 
 [dependencies]
-egui = "0.25.0"
-egui_extras = "0.25.0"
-eframe = { version = "0.25.0", default-features = false, features = [
+egui = "0.26.0"
+egui_extras = "0.26.0"
+eframe = { version = "0.26.0", default-features = false, features = [
     "accesskit",     # Make egui comptaible with screen readers. NOTE: adds a lot of dependencies.
     "default_fonts", # Embed the default egui fonts.
     "glow",          # Use the glow rendering backend. Alternative: "wgpu".

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -1764,7 +1764,9 @@ impl Window {
                 button_text.into_galley(ui, None, available_width, egui::TextStyle::Button);
             let button_size = button_text.size() + 2.0 * button_padding;
 
-            let query_size = ui.available_size().x - button_size.x - ui.spacing().item_spacing.x;
+            const MARGIN: f32 = 4.0; // From egui::TextEdit::margin
+            let query_size =
+                ui.available_size().x - button_size.x - ui.spacing().item_spacing.x - 2.0 * MARGIN;
             egui::TextEdit::singleline(&mut self.config.search_state.query)
                 .desired_width(query_size)
                 .show(ui);

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -468,13 +468,12 @@ impl Entry for Summary {
         cx.slot_rect = Some(rect); // Save slot rect for use later
 
         const TOOLTIP_RADIUS: f32 = 4.0;
-        let response = ui.allocate_rect(rect, egui::Sense::hover());
-        let hover_pos = response.hover_pos(); // where is the mouse hovering?
+        let hover_pos = ui.rect_hover_pos(rect); // where is the mouse hovering?
 
         self.inflate(config, cx);
 
         let style = ui.style();
-        let visuals = style.interact_selectable(&response, false);
+        let visuals = style.noninteractive();
         ui.painter()
             .rect(rect, 0.0, visuals.bg_fill, visuals.bg_stroke);
 
@@ -938,14 +937,13 @@ impl Entry for Slot {
     ) {
         cx.slot_rect = Some(rect); // Save slot rect for use later
 
-        let response = ui.allocate_rect(rect, egui::Sense::hover());
-        let mut hover_pos = response.hover_pos(); // where is the mouse hovering?
+        let mut hover_pos = ui.rect_hover_pos(rect); // where is the mouse hovering?
 
         if self.expanded {
             let tile_ids = self.inflate(config, cx);
 
             let style = ui.style();
-            let visuals = style.interact_selectable(&response, false);
+            let visuals = style.noninteractive();
             ui.painter()
                 .rect(rect, 0.0, visuals.bg_fill, visuals.bg_stroke);
 
@@ -2772,6 +2770,7 @@ trait UiExtra {
         rect: &Rect,
         add_contents: impl FnOnce(&mut egui::Ui),
     );
+    fn rect_hover_pos(&self, rect: Rect) -> Option<Pos2>;
 }
 
 impl UiExtra for egui::Ui {
@@ -2808,6 +2807,18 @@ impl UiExtra for egui::Ui {
             rect,
             add_contents,
         );
+    }
+
+    /// Starting with egui 0.26, ui.allocate_rect() never returns interactions
+    /// for multiple overlapping rectangles at once. This method is required to
+    /// interact for more complex widgets where we want to e.g., hover one
+    /// widget while dragging another widget (where those widgets overlap).
+    fn rect_hover_pos(&self, rect: Rect) -> Option<Pos2> {
+        if self.rect_contains_pointer(rect) {
+            self.input(|i| i.pointer.hover_pos())
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #71.

Notable updates:

 * Worked around https://github.com/emilk/egui/pull/3860 in egui 0.26 which prevented overlapping rectangles from receiving responses