### PR TITLE
Fix for loading older profiles, pre-color

### DIFF
--- a/examples/random_data.rs
+++ b/examples/random_data.rs
@@ -8,8 +8,8 @@ use std::sync::Mutex;
 
 use legion_prof_viewer::data::{
     DataSource, DataSourceDescription, DataSourceInfo, EntryID, EntryInfo, Field, FieldID,
-    FieldSchema, Item, ItemMeta, ItemUID, SlotMetaTile, SlotMetaTileData, SlotTile, SlotTileData,
-    SummaryTile, SummaryTileData, TileID, TileSet, UtilPoint,
+    FieldSchema, Item, ItemField, ItemMeta, ItemUID, SlotMetaTile, SlotMetaTileData, SlotTile,
+    SlotTileData, SummaryTile, SummaryTileData, TileID, TileSet, UtilPoint,
 };
 
 use legion_prof_viewer::deferred_data::DeferredDataSourceWrapper;
@@ -184,12 +184,12 @@ impl RandomDataSource {
                         original_interval: Interval::new(start, stop),
                         title: "Test Item".to_owned(),
                         fields: vec![
-                            (
+                            ItemField(
                                 self.interval_field,
                                 Field::Interval(Interval::new(start, stop)),
                                 None,
                             ),
-                            (
+                            ItemField(
                                 self.item_uid_field,
                                 Field::U64(item_uid.0),
                                 Some(Color32::RED),

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -19,8 +19,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::tile_manager::TileManager;
 use crate::data::{
-    DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, FieldID, FieldSchema, ItemLink,
-    ItemMeta, ItemUID, SlotMetaTileData, SlotTileData, SummaryTileData, TileID, UtilPoint,
+    DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, FieldID, FieldSchema, ItemField,
+    ItemLink, ItemMeta, ItemUID, SlotMetaTileData, SlotTileData, SummaryTileData, TileID,
+    UtilPoint,
 };
 use crate::deferred_data::{
     CountingDeferredDataSource, DeferredDataSource, LruDeferredDataSource, TileResult,
@@ -799,7 +800,7 @@ impl Slot {
                     if cx.debug {
                         ui.label(format!("Item UID: {}", item_meta.item_uid.0));
                     }
-                    for (field_id, field, color) in &item_meta.fields {
+                    for ItemField(field_id, field, color) in &item_meta.fields {
                         let name = config.field_schema.get_name(*field_id).unwrap();
                         let text = format!("{}", FieldWithName(name, field));
                         if let Some(color) = color {
@@ -1318,7 +1319,9 @@ impl SearchState {
         let field = self.search_field;
         if field == self.title_field {
             self.is_string_match(&item.title)
-        } else if let Some((_, value, _)) = item.fields.iter().find(|(x, _, _)| *x == field) {
+        } else if let Some(ItemField(_, value, _)) =
+            item.fields.iter().find(|ItemField(x, _, _)| *x == field)
+        {
             self.is_field_match(value)
         } else {
             false
@@ -2479,7 +2482,7 @@ impl ProfApp {
                 if cx.debug {
                     show_row("Item UID", &Field::U64(item_meta.item_uid.0), None);
                 }
-                for (field_id, field, color) in &item_meta.fields {
+                for ItemField(field_id, field, color) in &item_meta.fields {
                     let name = field_schema.get_name(*field_id).unwrap();
                     show_row(name, field, *color);
                 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -153,6 +153,13 @@ pub struct Item {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ItemField(
+    pub FieldID,
+    pub Field,
+    #[serde(default)] pub Option<Color32>,
+);
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ItemMeta {
     pub item_uid: ItemUID,
     // As opposed to the interval in Item, which may get expanded for
@@ -160,7 +167,7 @@ pub struct ItemMeta {
     // entire duration of the original item, unexpanded and unsliced.
     pub original_interval: Interval,
     pub title: String,
-    pub fields: Vec<(FieldID, Field, Option<Color32>)>,
+    pub fields: Vec<ItemField>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -25,6 +25,7 @@ pub struct DataSourceInfo {
     pub interval: Interval,
     pub tile_set: TileSet,
     pub field_schema: FieldSchema,
+    #[serde(default)]
     pub warning_message: Option<String>,
 }
 

--- a/src/merge_data.rs
+++ b/src/merge_data.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 
 use crate::data::{
-    DataSourceDescription, DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, ItemLink,
-    ItemUID, SlotMetaTile, SlotTile, SummaryTile, TileID,
+    DataSourceDescription, DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, ItemField,
+    ItemLink, ItemUID, SlotMetaTile, SlotTile, SummaryTile, TileID,
 };
 use crate::deferred_data::{
     DeferredDataSource, SlotMetaTileResponse, SlotTileResponse, SummaryTileResponse,
@@ -178,7 +178,7 @@ impl MergeDeferredDataSource {
         for items in &mut tile.data.items {
             for item in items {
                 item.item_uid = self.map_src_to_dst_item_uid(idx, item.item_uid);
-                for (_, field, _) in &mut item.fields {
+                for ItemField(_, field, _) in &mut item.fields {
                     self.map_src_to_dst_field(idx, field);
                 }
             }


### PR DESCRIPTION
Fixes profiles from before colors were added to the field tuple in `ItemMeta`. Note this is an API change but makes our serializer compatible with older profiles.