### PR TITLE
Load profiles from disk when URL parsing fails

### DIFF
--- a/examples/random_data.rs
+++ b/examples/random_data.rs
@@ -7,10 +7,9 @@ use std::collections::BTreeMap;
 use std::sync::Mutex;
 
 use legion_prof_viewer::data::{
-    DataSource, DataSourceDescription, DataSourceInfo, EntryID, EntryInfo, Field, FieldID,
-    FieldSchema, Item, ItemField, ItemMeta, ItemUID, SlotMetaTile, SlotMetaTileData,
-    SlotMetaTileResult, SlotTile, SlotTileData, SlotTileResult, SummaryTile, SummaryTileData,
-    SummaryTileResult, TileID, TileSet, UtilPoint,
+    self, DataSource, DataSourceDescription, DataSourceInfo, EntryID, EntryInfo, Field, FieldID,
+    FieldSchema, Item, ItemField, ItemMeta, ItemUID, SlotMetaTile, SlotMetaTileData, SlotTile,
+    SlotTileData, SummaryTile, SummaryTileData, TileID, TileSet, UtilPoint,
 };
 
 use legion_prof_viewer::deferred_data::DeferredDataSourceWrapper;
@@ -270,8 +269,8 @@ impl DataSource for RandomDataSource {
             source_locator: vec!["Random Data Source".to_string()],
         }
     }
-    fn fetch_info(&self) -> DataSourceInfo {
-        self.info.clone()
+    fn fetch_info(&self) -> data::Result<DataSourceInfo> {
+        Ok(self.info.clone())
     }
 
     fn fetch_summary_tile(
@@ -279,7 +278,7 @@ impl DataSource for RandomDataSource {
         entry_id: &EntryID,
         tile_id: TileID,
         _full: bool,
-    ) -> SummaryTileResult {
+    ) -> data::Result<SummaryTile> {
         let utilization = self.generate_summary(entry_id);
 
         let mut tile_utilization = Vec::new();
@@ -325,7 +324,12 @@ impl DataSource for RandomDataSource {
         })
     }
 
-    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, _full: bool) -> SlotTileResult {
+    fn fetch_slot_tile(
+        &self,
+        entry_id: &EntryID,
+        tile_id: TileID,
+        _full: bool,
+    ) -> data::Result<SlotTile> {
         let items = &self.generate_slot(entry_id).0;
 
         let mut slot_items = Vec::new();
@@ -355,7 +359,7 @@ impl DataSource for RandomDataSource {
         entry_id: &EntryID,
         tile_id: TileID,
         _full: bool,
-    ) -> SlotMetaTileResult {
+    ) -> data::Result<SlotMetaTile> {
         let (items, item_metas) = self.generate_slot(entry_id);
 
         let mut slot_items = Vec::new();

--- a/examples/random_data.rs
+++ b/examples/random_data.rs
@@ -8,8 +8,9 @@ use std::sync::Mutex;
 
 use legion_prof_viewer::data::{
     DataSource, DataSourceDescription, DataSourceInfo, EntryID, EntryInfo, Field, FieldID,
-    FieldSchema, Item, ItemField, ItemMeta, ItemUID, SlotMetaTile, SlotMetaTileData, SlotTile,
-    SlotTileData, SummaryTile, SummaryTileData, TileID, TileSet, UtilPoint,
+    FieldSchema, Item, ItemField, ItemMeta, ItemUID, SlotMetaTile, SlotMetaTileData,
+    SlotMetaTileResult, SlotTile, SlotTileData, SlotTileResult, SummaryTile, SummaryTileData,
+    SummaryTileResult, TileID, TileSet, UtilPoint,
 };
 
 use legion_prof_viewer::deferred_data::DeferredDataSourceWrapper;
@@ -273,7 +274,12 @@ impl DataSource for RandomDataSource {
         self.info.clone()
     }
 
-    fn fetch_summary_tile(&self, entry_id: &EntryID, tile_id: TileID, _full: bool) -> SummaryTile {
+    fn fetch_summary_tile(
+        &self,
+        entry_id: &EntryID,
+        tile_id: TileID,
+        _full: bool,
+    ) -> SummaryTileResult {
         let utilization = self.generate_summary(entry_id);
 
         let mut tile_utilization = Vec::new();
@@ -310,16 +316,16 @@ impl DataSource for RandomDataSource {
 
             last_point = Some(point);
         }
-        SummaryTile {
+        Ok(SummaryTile {
             entry_id: entry_id.clone(),
             tile_id,
             data: SummaryTileData {
                 utilization: tile_utilization,
             },
-        }
+        })
     }
 
-    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, _full: bool) -> SlotTile {
+    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, _full: bool) -> SlotTileResult {
         let items = &self.generate_slot(entry_id).0;
 
         let mut slot_items = Vec::new();
@@ -337,11 +343,11 @@ impl DataSource for RandomDataSource {
             slot_items.push(slot_row);
         }
 
-        SlotTile {
+        Ok(SlotTile {
             entry_id: entry_id.clone(),
             tile_id,
             data: SlotTileData { items: slot_items },
-        }
+        })
     }
 
     fn fetch_slot_meta_tile(
@@ -349,7 +355,7 @@ impl DataSource for RandomDataSource {
         entry_id: &EntryID,
         tile_id: TileID,
         _full: bool,
-    ) -> SlotMetaTile {
+    ) -> SlotMetaTileResult {
         let (items, item_metas) = self.generate_slot(entry_id);
 
         let mut slot_items = Vec::new();
@@ -365,10 +371,10 @@ impl DataSource for RandomDataSource {
             slot_items.push(slot_row);
         }
 
-        SlotMetaTile {
+        Ok(SlotMetaTile {
             entry_id: entry_id.clone(),
             tile_id,
             data: SlotMetaTileData { items: slot_items },
-        }
+        })
     }
 }

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -21,11 +21,9 @@ use crate::app::tile_manager::TileManager;
 use crate::data::{
     DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, FieldID, FieldSchema, ItemField,
     ItemLink, ItemMeta, ItemUID, SlotMetaTileData, SlotTileData, SummaryTileData, TileID,
-    UtilPoint,
+    TileResult, UtilPoint,
 };
-use crate::deferred_data::{
-    CountingDeferredDataSource, DeferredDataSource, LruDeferredDataSource, TileResult,
-};
+use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource, LruDeferredDataSource};
 use crate::timestamp::{
     Interval, Timestamp, TimestampDisplay, TimestampParseError, TimestampUnits,
 };

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -19,9 +19,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::tile_manager::TileManager;
 use crate::data::{
-    DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, FieldID, FieldSchema, ItemField,
+    self, DataSourceInfo, EntryID, EntryIndex, EntryInfo, Field, FieldID, FieldSchema, ItemField,
     ItemLink, ItemMeta, ItemUID, SlotMetaTileData, SlotTileData, SummaryTileData, TileID,
-    TileResult, UtilPoint,
+    UtilPoint,
 };
 use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource, LruDeferredDataSource};
 use crate::timestamp::{
@@ -62,7 +62,7 @@ use crate::timestamp::{
 struct Summary {
     entry_id: EntryID,
     color: Color32,
-    tiles: BTreeMap<TileID, Option<TileResult<SummaryTileData>>>,
+    tiles: BTreeMap<TileID, Option<data::Result<SummaryTileData>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -79,9 +79,9 @@ struct Slot {
     //  2. None: awaiting response.
     //  3. Some(Err(_)): response failed or returned with an error.
     //  4. Some(Ok(_)): successfully completed response.
-    tiles: BTreeMap<TileID, Option<TileResult<SlotTileData>>>,
-    tile_metas: BTreeMap<TileID, Option<TileResult<SlotMetaTileData>>>,
-    tile_metas_full: BTreeMap<TileID, Option<TileResult<SlotMetaTileData>>>,
+    tiles: BTreeMap<TileID, Option<data::Result<SlotTileData>>>,
+    tile_metas: BTreeMap<TileID, Option<data::Result<SlotMetaTileData>>>,
+    tile_metas_full: BTreeMap<TileID, Option<data::Result<SlotMetaTileData>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -644,7 +644,7 @@ impl Slot {
         tile_id: TileID,
         config: &mut Config,
         full: bool,
-    ) -> Option<&TileResult<SlotMetaTileData>> {
+    ) -> Option<&data::Result<SlotMetaTileData>> {
         let metas = if full {
             &mut self.tile_metas_full
         } else {
@@ -2515,6 +2515,8 @@ impl eframe::App for ProfApp {
             // We made one request, so we know there is always zero or one
             // elements in this list.
             if let Some(info) = source.get_infos().pop() {
+                // TODO: show this in a more user-friendly way.
+                let info = info.expect("fetch_info failed");
                 let window = Window::new(source, info, windows.len() as u64);
                 if windows.is_empty() {
                     cx.total_interval = window.config.interval;

--- a/src/archive_data.rs
+++ b/src/archive_data.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::data::{DataSourceInfo, EntryID, EntryIDSlug, EntryIndex, EntryInfo, TileID, TileSet};
+use crate::data::{
+    self, DataSourceInfo, EntryID, EntryIDSlug, EntryIndex, EntryInfo, TileID, TileSet,
+};
 use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource};
 use crate::http::schema::TileRequestRef;
 use crate::timestamp::{Interval, Timestamp};
@@ -110,7 +112,7 @@ impl<T: DeferredDataSource> DataSourceArchiveWriter<T> {
         }
     }
 
-    fn check_info(&mut self) -> Option<DataSourceInfo> {
+    fn check_info(&mut self) -> Option<data::Result<DataSourceInfo>> {
         // We requested this once, so we know we'll get zero or one result
         self.data_source.get_infos().pop()
     }
@@ -171,7 +173,7 @@ impl<T: DeferredDataSource> DataSourceArchiveWriter<T> {
         while info.is_none() {
             info = self.check_info();
         }
-        let mut info = info.unwrap();
+        let mut info = info.unwrap().expect("fetch_info failed");
 
         let entry_ids = walk_entry_list(&info.entry_info);
         for entry_id in &entry_ids {

--- a/src/data.rs
+++ b/src/data.rs
@@ -220,13 +220,28 @@ pub struct DataSourceDescription {
     pub source_locator: Vec<String>,
 }
 
+pub type TileResult<T> = Result<T, String>;
+
+pub type SummaryTileResult = TileResult<SummaryTile>;
+pub type SlotTileResult = TileResult<SlotTile>;
+pub type SlotMetaTileResult = TileResult<SlotMetaTile>;
+
 pub trait DataSource {
     fn fetch_description(&self) -> DataSourceDescription;
     fn fetch_info(&self) -> DataSourceInfo;
-    fn fetch_summary_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SummaryTile;
-    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SlotTile;
-    fn fetch_slot_meta_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool)
-    -> SlotMetaTile;
+    fn fetch_summary_tile(
+        &self,
+        entry_id: &EntryID,
+        tile_id: TileID,
+        full: bool,
+    ) -> SummaryTileResult;
+    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SlotTileResult;
+    fn fetch_slot_meta_tile(
+        &self,
+        entry_id: &EntryID,
+        tile_id: TileID,
+        full: bool,
+    ) -> SlotMetaTileResult;
 }
 
 impl EntryID {

--- a/src/data.rs
+++ b/src/data.rs
@@ -220,28 +220,24 @@ pub struct DataSourceDescription {
     pub source_locator: Vec<String>,
 }
 
-pub type TileResult<T> = Result<T, String>;
-
-pub type SummaryTileResult = TileResult<SummaryTile>;
-pub type SlotTileResult = TileResult<SlotTile>;
-pub type SlotMetaTileResult = TileResult<SlotMetaTile>;
+pub type Result<T> = std::result::Result<T, String>;
 
 pub trait DataSource {
     fn fetch_description(&self) -> DataSourceDescription;
-    fn fetch_info(&self) -> DataSourceInfo;
+    fn fetch_info(&self) -> Result<DataSourceInfo>;
     fn fetch_summary_tile(
         &self,
         entry_id: &EntryID,
         tile_id: TileID,
         full: bool,
-    ) -> SummaryTileResult;
-    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool) -> SlotTileResult;
+    ) -> Result<SummaryTile>;
+    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, full: bool) -> Result<SlotTile>;
     fn fetch_slot_meta_tile(
         &self,
         entry_id: &EntryID,
         tile_id: TileID,
         full: bool,
-    ) -> SlotMetaTileResult;
+    ) -> Result<SlotMetaTile>;
 }
 
 impl EntryID {
@@ -307,8 +303,8 @@ impl EntryID {
         true
     }
 
-    pub fn from_slug(s: &str) -> Result<Self, std::num::ParseIntError> {
-        let elts: Result<Vec<_>, _> = s.split('_').map(|x| x.parse::<i64>()).collect();
+    pub fn from_slug(s: &str) -> std::result::Result<Self, std::num::ParseIntError> {
+        let elts: std::result::Result<Vec<_>, _> = s.split('_').map(|x| x.parse::<i64>()).collect();
         Ok(Self(elts?))
     }
 }
@@ -397,8 +393,9 @@ impl From<std::num::ParseIntError> for SlugParseError {
 }
 
 impl TileID {
-    pub fn from_slug(s: &str) -> Result<Self, SlugParseError> {
-        let elts: Result<Vec<i64>, _> = s.split('_').map(|x| x.parse::<i64>()).collect();
+    pub fn from_slug(s: &str) -> std::result::Result<Self, SlugParseError> {
+        let elts: std::result::Result<Vec<i64>, _> =
+            s.split('_').map(|x| x.parse::<i64>()).collect();
         match elts?.as_slice() {
             [start, stop] => Ok(Self(Interval::new(Timestamp(*start), Timestamp(*stop)))),
             [_] => Err(SlugParseError::TooFewValues),

--- a/src/deferred_data.rs
+++ b/src/deferred_data.rs
@@ -4,7 +4,7 @@ use lru::LruCache;
 
 use crate::data::{
     DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile,
-    SummaryTile, TileID,
+    SummaryTile, TileID, TileResult,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -14,12 +14,7 @@ pub struct TileRequest {
     pub full: bool,
 }
 
-pub type TileResult<T> = Result<T, String>;
 pub type TileResponse<T> = (TileResult<T>, TileRequest);
-
-pub type SummaryTileResult = TileResult<SummaryTile>;
-pub type SlotTileResult = TileResult<SlotTile>;
-pub type SlotMetaTileResult = TileResult<SlotMetaTile>;
 
 pub type SummaryTileResponse = TileResponse<SummaryTile>;
 pub type SlotTileResponse = TileResponse<SlotTile>;
@@ -72,7 +67,7 @@ impl<T: DataSource> DeferredDataSource for DeferredDataSourceWrapper<T> {
 
     fn fetch_summary_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) {
         self.summary_tiles.push((
-            Ok(self.data_source.fetch_summary_tile(entry_id, tile_id, full)),
+            self.data_source.fetch_summary_tile(entry_id, tile_id, full),
             TileRequest {
                 entry_id: entry_id.clone(),
                 tile_id,
@@ -87,7 +82,7 @@ impl<T: DataSource> DeferredDataSource for DeferredDataSourceWrapper<T> {
 
     fn fetch_slot_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) {
         self.slot_tiles.push((
-            Ok(self.data_source.fetch_slot_tile(entry_id, tile_id, full)),
+            self.data_source.fetch_slot_tile(entry_id, tile_id, full),
             TileRequest {
                 entry_id: entry_id.clone(),
                 tile_id,
@@ -102,9 +97,8 @@ impl<T: DataSource> DeferredDataSource for DeferredDataSourceWrapper<T> {
 
     fn fetch_slot_meta_tile(&mut self, entry_id: &EntryID, tile_id: TileID, full: bool) {
         self.slot_meta_tiles.push((
-            Ok(self
-                .data_source
-                .fetch_slot_meta_tile(entry_id, tile_id, full)),
+            self.data_source
+                .fetch_slot_meta_tile(entry_id, tile_id, full),
             TileRequest {
                 entry_id: entry_id.clone(),
                 tile_id,

--- a/src/file_data.rs
+++ b/src/file_data.rs
@@ -38,7 +38,8 @@ impl DataSource for FileDataSource {
     }
     fn fetch_info(&self) -> DataSourceInfo {
         let path = self.basedir.join("info");
-        self.read_file::<DataSourceInfo>(&path).expect("fetch_info failed")
+        self.read_file::<DataSourceInfo>(&path)
+            .expect("fetch_info failed")
     }
 
     fn fetch_summary_tile(

--- a/src/file_data.rs
+++ b/src/file_data.rs
@@ -38,7 +38,7 @@ impl DataSource for FileDataSource {
     }
     fn fetch_info(&self) -> DataSourceInfo {
         let path = self.basedir.join("info");
-        self.read_file::<DataSourceInfo>(&path).unwrap()
+        self.read_file::<DataSourceInfo>(&path).expect("fetch_info failed")
     }
 
     fn fetch_summary_tile(

--- a/src/file_data.rs
+++ b/src/file_data.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::data::{
-    DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotMetaTileResult,
-    SlotTile, SlotTileResult, SummaryTile, SummaryTileResult, TileID, TileResult,
+    self, DataSource, DataSourceDescription, DataSourceInfo, EntryID, SlotMetaTile, SlotTile,
+    SummaryTile, TileID,
 };
 use crate::http::schema::TileRequestRef;
 
@@ -20,7 +20,7 @@ impl FileDataSource {
         }
     }
 
-    fn read_file<T>(&self, path: impl AsRef<Path>) -> TileResult<T>
+    fn read_file<T>(&self, path: impl AsRef<Path>) -> data::Result<T>
     where
         T: for<'a> Deserialize<'a>,
     {
@@ -36,10 +36,9 @@ impl DataSource for FileDataSource {
             source_locator: vec![String::from(self.basedir.to_string_lossy())],
         }
     }
-    fn fetch_info(&self) -> DataSourceInfo {
+    fn fetch_info(&self) -> data::Result<DataSourceInfo> {
         let path = self.basedir.join("info");
         self.read_file::<DataSourceInfo>(&path)
-            .expect("fetch_info failed")
     }
 
     fn fetch_summary_tile(
@@ -47,14 +46,19 @@ impl DataSource for FileDataSource {
         entry_id: &EntryID,
         tile_id: TileID,
         _full: bool,
-    ) -> SummaryTileResult {
+    ) -> data::Result<SummaryTile> {
         let req = TileRequestRef { entry_id, tile_id };
         let mut path = self.basedir.join("summary_tile");
         path.push(req.to_slug());
         self.read_file::<SummaryTile>(&path)
     }
 
-    fn fetch_slot_tile(&self, entry_id: &EntryID, tile_id: TileID, _full: bool) -> SlotTileResult {
+    fn fetch_slot_tile(
+        &self,
+        entry_id: &EntryID,
+        tile_id: TileID,
+        _full: bool,
+    ) -> data::Result<SlotTile> {
         let req = TileRequestRef { entry_id, tile_id };
         let mut path = self.basedir.join("slot_tile");
         path.push(req.to_slug());
@@ -66,7 +70,7 @@ impl DataSource for FileDataSource {
         entry_id: &EntryID,
         tile_id: TileID,
         _full: bool,
-    ) -> SlotMetaTileResult {
+    ) -> data::Result<SlotMetaTile> {
         let req = TileRequestRef { entry_id, tile_id };
         let mut path = self.basedir.join("slot_meta_tile");
         path.push(req.to_slug());

--- a/src/nvtxw.rs
+++ b/src/nvtxw.rs
@@ -8,7 +8,9 @@ use std::ptr::{null, null_mut};
 
 use nvtxw::nvtxw;
 
-use crate::data::{DataSourceInfo, EntryID, EntryIndex, EntryInfo, SlotMetaTile, SlotTile, TileID};
+use crate::data::{
+    self, DataSourceInfo, EntryID, EntryIndex, EntryInfo, SlotMetaTile, SlotTile, TileID,
+};
 use crate::deferred_data::{CountingDeferredDataSource, DeferredDataSource};
 
 const LEGION_DOMAIN_NAME: &str = "Legion";
@@ -118,7 +120,7 @@ impl<T: DeferredDataSource> NVTXW<T> {
         }
     }
 
-    fn check_info(&mut self) -> Option<DataSourceInfo> {
+    fn check_info(&mut self) -> Option<data::Result<DataSourceInfo>> {
         // We requested this once, so we know we'll get zero or one result
         self.data_source.get_infos().pop()
     }
@@ -220,7 +222,7 @@ impl<T: DeferredDataSource> NVTXW<T> {
         while info.is_none() {
             info = self.check_info();
         }
-        let info = info.unwrap();
+        let info = info.unwrap().expect("fetch_info failed");
 
         let entry_ids = walk_entry_list(&info.entry_info);
 

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -54,7 +54,7 @@ impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDefer
                 tile_id,
                 full,
             };
-            summary_tiles.lock().unwrap().push((Ok(result), req));
+            summary_tiles.lock().unwrap().push((result, req));
         });
     }
 
@@ -73,7 +73,7 @@ impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDefer
                 tile_id,
                 full,
             };
-            slot_tiles.lock().unwrap().push((Ok(result), req));
+            slot_tiles.lock().unwrap().push((result, req));
         });
     }
 
@@ -92,7 +92,7 @@ impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDefer
                 tile_id,
                 full,
             };
-            slot_meta_tiles.lock().unwrap().push((Ok(result), req));
+            slot_meta_tiles.lock().unwrap().push((result, req));
         });
     }
 

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -1,13 +1,13 @@
 use std::sync::{Arc, Mutex};
 
-use crate::data::{DataSource, DataSourceDescription, DataSourceInfo, EntryID, TileID};
+use crate::data::{self, DataSource, DataSourceDescription, DataSourceInfo, EntryID, TileID};
 use crate::deferred_data::{
     DeferredDataSource, SlotMetaTileResponse, SlotTileResponse, SummaryTileResponse, TileRequest,
 };
 
 pub struct ParallelDeferredDataSource<T: DataSource + Send + Sync + 'static> {
     data_source: Arc<T>,
-    infos: Arc<Mutex<Vec<DataSourceInfo>>>,
+    infos: Arc<Mutex<Vec<data::Result<DataSourceInfo>>>>,
     summary_tiles: Arc<Mutex<Vec<SummaryTileResponse>>>,
     slot_tiles: Arc<Mutex<Vec<SlotTileResponse>>>,
     slot_meta_tiles: Arc<Mutex<Vec<SlotMetaTileResponse>>>,
@@ -39,7 +39,7 @@ impl<T: DataSource + Send + Sync + 'static> DeferredDataSource for ParallelDefer
         });
     }
 
-    fn get_infos(&mut self) -> Vec<DataSourceInfo> {
+    fn get_infos(&mut self) -> Vec<data::Result<DataSourceInfo>> {
         std::mem::take(&mut self.infos.lock().unwrap())
     }
 


### PR DESCRIPTION
Other changes:

 * `DataSource` now returns `data::Result` so that errors can be reported.
 * `fetch_info` now returns `data::Result` so that errors can be reported.
 * `FileDataSource` reports errors rather than crashing.
 * `HttpClientDataSource` reports errors for `fetch_info` rather than crashing.

Breaking API change.

Partially address #94 (in the crate binary `main`).