### PR TITLE
Foward errors from failed HTTP requests

### DIFF
--- a/src/http/fetch_native.rs
+++ b/src/http/fetch_native.rs
@@ -7,12 +7,12 @@ pub fn fetch(
     on_done: Box<dyn FnOnce(Result<DataSourceResponse, String>) + Send>,
 ) {
     rayon::spawn(move || {
-        let result = request
+        let response = request
             .send()
-            .expect("request failed")
-            .bytes()
-            .expect("unable to get bytes");
+            .map_err(|e| format!("request failed: {e}"))
+            .and_then(|r| r.bytes().map_err(|e| format!("unable to get bytes: {e}")))
+            .map(|r| DataSourceResponse { body: r });
 
-        on_done(Ok(DataSourceResponse { body: result }))
+        on_done(response)
     });
 }

--- a/src/http/fetch_web.rs
+++ b/src/http/fetch_web.rs
@@ -21,13 +21,15 @@ pub fn fetch(
         let response = request
             .send()
             .await
-            .map_err(|e| format!("request failed: {e}"))
-            .and_then(async |r| {
-                r.bytes()
-                    .await
-                    .map_err(|e| format!("unable to get bytes: {e}"))
-            })
-            .map(|r| DataSourceResponse { body: r });
+            .map_err(|e| format!("request failed: {e}"));
+        let response = match response {
+            Ok(r) => r
+                .bytes()
+                .await
+                .map_err(|e| format!("unable to get bytes: {e}")),
+            Err(e) => Err(e),
+        };
+        let response = response.map(|r| DataSourceResponse { body: r });
 
         on_done(response)
     });

--- a/src/http/fetch_web.rs
+++ b/src/http/fetch_web.rs
@@ -21,13 +21,14 @@ pub fn fetch(
         let result = request
             .send()
             .await
-            .expect("request failed")
-            .bytes()
-            .await
-            .expect("unable to get bytes");
+            .map_err(|e| format!("request failed: {e}"))
+            .and_then(|r| {
+                r.bytes()
+                    .await
+                    .map_err(|e| format!("unable to get bytes: {e}"))
+            })
+            .map(|r| DataSourceResponse { body: r });
 
-        let res = Ok(DataSourceResponse { body: result });
-
-        on_done(res)
+        on_done(response)
     });
 }

--- a/src/http/fetch_web.rs
+++ b/src/http/fetch_web.rs
@@ -18,11 +18,11 @@ pub fn fetch(
     on_done: Box<dyn FnOnce(Result<DataSourceResponse, String>) + Send>,
 ) {
     spawn_future(async move {
-        let result = request
+        let response = request
             .send()
             .await
             .map_err(|e| format!("request failed: {e}"))
-            .and_then(|r| {
+            .and_then(async |r| {
                 r.bytes()
                     .await
                     .map_err(|e| format!("unable to get bytes: {e}"))


### PR DESCRIPTION
This enables them to be passed fully through the infrastructure so we don't just crash when a request fails.