### PR TITLE
Modernize GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2 # repo checkout
+      - uses: actions/checkout@v3 # repo checkout
       - uses: actions-rs/toolchain@v1 # get rust toolchain for wasm
         with:
           profile: minimal

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,13 +19,10 @@ jobs:
     name: Build GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 # repo checkout
-      - uses: actions-rs/toolchain@v1 # get rust toolchain for wasm
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.85.1
         with:
-          profile: minimal
-          toolchain: 1.85.1
           target: wasm32-unknown-unknown
-          override: true
       - name: Rust Cache # cache the rust build artefacts
         uses: Swatinem/rust-cache@v1
       - name: Download and install Trunk binary

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,8 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           target: wasm32-unknown-unknown
-      - name: Rust Cache # cache the rust build artefacts
-        uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Download and install Trunk binary
         run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.8/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
       - name: Build # build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           target: wasm32-unknown-unknown

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.85.1
+        with:
+          components: rustfmt
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -62,6 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.85.1
+        with:
+          components: clippy
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
   trunk:
@@ -70,5 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.85.1
+        with:
+          target: wasm32-unknown-unknown
       - run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.8/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
       - run: ./trunk build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,12 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.85.1
-          override: true
-          components: rustfmt
+      - uses: dtolnay/rust-toolchain@1.85.1
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -66,12 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.85.1
-          override: true
-          components: clippy
+      - uses: dtolnay/rust-toolchain@1.85.1
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
   trunk:
@@ -79,11 +69,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.85.1
-          target: wasm32-unknown-unknown
-          override: true
+      - uses: dtolnay/rust-toolchain@1.85.1
       - run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.8/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
       - run: ./trunk build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.85.1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo check --no-default-features --lib
       - run: cargo check --no-default-features --features client --all-targets
       - run: cargo check --no-default-features --features server --lib
@@ -23,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.85.1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo check --no-default-features --lib
       - run: cargo check --no-default-features --features client --all-targets
       - run: cargo check --no-default-features --features server --lib
@@ -36,6 +38,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           target: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - run: cargo check --no-default-features --lib --target wasm32-unknown-unknown
       - run: cargo check --no-default-features --features client --lib --target wasm32-unknown-unknown
 
@@ -45,6 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.85.1
+      - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev
       - run: cargo test --lib --all-features
 
@@ -56,6 +60,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
   clippy:
@@ -66,6 +71,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
   trunk:
@@ -76,5 +82,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           target: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.8/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
       - run: ./trunk build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
 
   clippy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,22 +16,10 @@ jobs:
           profile: minimal
           toolchain: 1.85.1
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --lib
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features client --all-targets
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features server --lib
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --all-targets
+      - run: cargo check --no-default-features --lib
+      - run: cargo check --no-default-features --features client --all-targets
+      - run: cargo check --no-default-features --features server --lib
+      - run: cargo check --all-features --all-targets
 
   check_mac:
     name: Check macOS
@@ -43,22 +31,10 @@ jobs:
           profile: minimal
           toolchain: 1.85.1
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --lib
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features client --all-targets
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features server --lib
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --all-targets
+      - run: cargo check --no-default-features --lib
+      - run: cargo check --no-default-features --features client --all-targets
+      - run: cargo check --no-default-features --features server --lib
+      - run: cargo check --all-features --all-targets
 
   check_wasm:
     name: Check wasm32
@@ -71,14 +47,8 @@ jobs:
           toolchain: 1.85.1
           target: wasm32-unknown-unknown
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --lib --target wasm32-unknown-unknown
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features client --lib --target wasm32-unknown-unknown
+      - run: cargo check --no-default-features --lib --target wasm32-unknown-unknown
+      - run: cargo check --no-default-features --features client --lib --target wasm32-unknown-unknown
 
   test:
     name: Test Suite
@@ -91,10 +61,7 @@ jobs:
           toolchain: 1.85.1
           override: true
       - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --all-features
+      - run: cargo test --lib --all-features
 
   fmt:
     name: Rustfmt
@@ -107,10 +74,7 @@ jobs:
           toolchain: 1.85.1
           override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -123,10 +87,7 @@ jobs:
           toolchain: 1.85.1
           override: true
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets -- -D warnings
+      - run: cargo clippy --all-features --all-targets -- -D warnings
 
   trunk:
     name: Trunk
@@ -139,7 +100,5 @@ jobs:
           toolchain: 1.85.1
           target: wasm32-unknown-unknown
           override: true
-      - name: Download and install Trunk binary
-        run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.8/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
-      - name: Build
-        run: ./trunk build
+      - run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.8/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+      - run: ./trunk build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.85.1
-          override: true
+      - uses: dtolnay/rust-toolchain@1.85.1
       - run: cargo check --no-default-features --lib
       - run: cargo check --no-default-features --features client --all-targets
       - run: cargo check --no-default-features --features server --lib
@@ -26,11 +22,7 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.85.1
-          override: true
+      - uses: dtolnay/rust-toolchain@1.85.1
       - run: cargo check --no-default-features --lib
       - run: cargo check --no-default-features --features client --all-targets
       - run: cargo check --no-default-features --features server --lib
@@ -41,12 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.85.1
         with:
-          profile: minimal
-          toolchain: 1.85.1
           target: wasm32-unknown-unknown
-          override: true
       - run: cargo check --no-default-features --lib --target wasm32-unknown-unknown
       - run: cargo check --no-default-features --features client --lib --target wasm32-unknown-unknown
 
@@ -55,11 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.85.1
-          override: true
+      - uses: dtolnay/rust-toolchain@1.85.1
       - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev
       - run: cargo test --lib --all-features
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --no-default-features --lib
@@ -22,7 +22,7 @@ jobs:
     name: Check macOS
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --no-default-features --lib
@@ -34,7 +34,7 @@ jobs:
     name: Check wasm32
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           target: wasm32-unknown-unknown
@@ -46,7 +46,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev
@@ -56,7 +56,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           components: rustfmt
@@ -66,7 +66,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           components: clippy
@@ -77,7 +77,7 @@ jobs:
     name: Trunk
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.1
         with:
           target: wasm32-unknown-unknown


### PR DESCRIPTION
 * Remove `actions-rs` actions because they are now archived
 * For `cargo` commands, just run them directly
 * For toolchain actions, use `dtolnay`'s replacement
 * Cache all build artifacts for faster CI
 * Upgrade to `actions/checkout@v4`
 * Remove a bunch of self-explanatory build step names