### PR TITLE
Fix empty Vec in DuckDB database

### DIFF
--- a/src/duckdb_data.rs
+++ b/src/duckdb_data.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 
 use duckdb::{Connection, params};
 use itertools::Itertools;
+use log::info;
 use regex::Regex;
 
 use crate::app::tile_manager::TileManager;
@@ -208,7 +209,7 @@ impl<T: DeferredDataSource> DataSourceDuckDBWriter<T> {
         field_name: &str,
         field_type: &FieldType,
     ) -> duckdb::Result<()> {
-        println!("add_entry_field {field_name} {field_type:?}");
+        info!("add_entry_field {field_name} {field_type:?}");
         conn.execute(
             &format!(
                 "ALTER TABLE items ADD COLUMN {} {}",
@@ -228,7 +229,7 @@ impl<T: DeferredDataSource> DataSourceDuckDBWriter<T> {
         old_type: &FieldType,
         new_type: &FieldType,
     ) -> duckdb::Result<()> {
-        println!("upgrade_entry_field {field_name} {old_type:?} {new_type:?}");
+        info!("upgrade_entry_field {field_name} {old_type:?} {new_type:?}");
         conn.execute(
             &SqlType(old_type).upgrade_column("items", field_name, &SqlType(new_type)),
             [],

--- a/src/duckdb_data.rs
+++ b/src/duckdb_data.rs
@@ -475,7 +475,9 @@ impl SqlType<'_> {
                          )
                      );"
                 ),
-                _ => panic!("don't know how to perform upgrade from {self:?} to {to_type:?}"),
+                _ => panic!(
+                    "don't know how to perform upgrade from Vec({self:?}) to Vec({to_type:?})"
+                ),
             },
             _ => panic!("don't know how to perform upgrade from {self:?} to {to_type:?}"),
         }

--- a/src/duckdb_data.rs
+++ b/src/duckdb_data.rs
@@ -461,6 +461,7 @@ impl SqlType<'_> {
                 // Hack: DuckDB does not appear to correctly bind the parameter
                 // x, so we replace it here with a dummy. We know the Vec is
                 // empty anyway, so it shouldn't matter.
+                // https://github.com/duckdb/duckdb/issues/17803
                 (FieldType::Unknown, FieldType::ItemLink) => format!(
                     "ALTER TABLE {table_name}
                      ALTER COLUMN {column_name} TYPE {to_type}

--- a/src/duckdb_data.rs
+++ b/src/duckdb_data.rs
@@ -458,9 +458,10 @@ impl SqlType<'_> {
                 )
             }
             (FieldType::Vec(from_elt), FieldType::Vec(to_elt)) => match (&**from_elt, &**to_elt) {
-                (FieldType::U64, FieldType::ItemLink)
-                | (FieldType::String, FieldType::ItemLink)
-                | (FieldType::Unknown, FieldType::ItemLink) => format!(
+                // Hack: DuckDB does not appear to correctly bind the parameter
+                // x, so we replace it here with a dummy. We know the Vec is
+                // empty anyway, so it shouldn't matter.
+                (FieldType::Unknown, FieldType::ItemLink) => format!(
                     "ALTER TABLE {table_name}
                      ALTER COLUMN {column_name} TYPE {to_type}
                      USING (
@@ -468,7 +469,7 @@ impl SqlType<'_> {
                              {column_name},
                              lambda x: {{
                                  'item_uid': NULL,
-                                 'title': x,
+                                 'title': 'dummy',
                                  'interval': {{'start': NULL, 'stop': NULL, 'duration': NULL}},
                                  'entry_slug': NULL,
                              }}


### PR DESCRIPTION
Sometimes we encounter an empty `Vec` with no hint about what should go inside it. In these cases, we have to generate a dummy entry so we have *something* in the database.

Also add an upgrade path so once a real value comes along we can harmonize the dummy and real values.

Note: this PR contains a workaround for https://github.com/duckdb/duckdb/issues/17803 since apparently lambdas are broken in DuckDB.