### PR TITLE
Add x11 support to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ eframe = { version = "0.30.0", default-features = false, features = [
     "glow",          # Use the glow rendering backend. Alternative: "wgpu".
     "persistence",   # Enable restoring app state when restarting the app.
     "wayland",       # To support Linux (and CI)
+    "x11",           # To support X11 on Linux
 ] }
 log = "0.4"
 


### PR DESCRIPTION
Explicitly request x11 support from `eframe`, so the app also works on non-Wayland machines.